### PR TITLE
Add a new API to `metriken-core` to allow metrics to dynamically provide fields to the consumer

### DIFF
--- a/metriken-core/src/dynmetrics.rs
+++ b/metriken-core/src/dynmetrics.rs
@@ -10,8 +10,6 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
-use std::marker::PhantomPinned;
-use std::mem::ManuallyDrop;
 use std::ops::Deref;
 use std::pin::Pin;
 
@@ -19,6 +17,8 @@ use std::pin::Pin;
 use parking_lot::{const_rwlock, RwLock, RwLockReadGuard};
 
 use crate::null::NullMetric;
+use crate::provide::ProviderMap;
+use crate::wrapper::FormattingFn;
 use crate::{default_formatter, Format, Metadata, Metric, MetricEntry};
 
 pub(crate) struct DynMetricsRegistry {
@@ -63,6 +63,7 @@ pub(crate) fn get_registry() -> RwLockReadGuard<'static, DynMetricsRegistry> {
 pub struct MetricBuilder {
     name: Cow<'static, str>,
     desc: Option<Cow<'static, str>>,
+    provider: ProviderMap,
     metadata: HashMap<String, String>,
     formatter: fn(&MetricEntry, Format) -> String,
 }
@@ -73,6 +74,7 @@ impl MetricBuilder {
         Self {
             name: name.into(),
             desc: None,
+            provider: ProviderMap::new(),
             metadata: HashMap::new(),
             formatter: default_formatter,
         }
@@ -90,25 +92,51 @@ impl MetricBuilder {
         self
     }
 
-    pub fn formatter(mut self, formatter: fn(&MetricEntry, Format) -> String) -> Self {
-        self.formatter = formatter;
+    pub fn formatter(self, formatter: fn(&MetricEntry, Format) -> String) -> Self {
+        self.provide(FormattingFn(formatter))
+    }
+
+    /// Add provided type data to this metric.
+    ///
+    /// These can then be accessed via [`MetricEntry::request_ref`].
+    pub fn provide<T: Send + Sync + 'static>(mut self, value: T) -> Self {
+        self.provider.insert(value);
         self
     }
 
     /// Convert this builder directly into a [`MetricEntry`].
-    pub fn into_entry(self) -> MetricEntry {
+    pub fn into_entry(mut self) -> MetricEntry {
+        self.take_entry()
+    }
+
+    /// Create a [`MetricEntry`] by taking config values out of this builder.
+    pub fn take_entry(&mut self) -> MetricEntry {
         MetricEntry {
             metric: &NullMetric,
-            name: self.name,
-            description: self.desc,
-            metadata: Metadata::new(self.metadata),
-            formatter: self.formatter,
+            name: std::mem::take(&mut self.name),
+            description: std::mem::take(&mut self.desc),
         }
     }
 
     /// Build a [`DynBoxedMetric`] for use with this builder.
-    pub fn build<T: Metric>(self, metric: T) -> DynBoxedMetric<T> {
-        DynBoxedMetric::new(metric, self.into_entry())
+    pub fn build<T: Metric>(mut self, metric: T) -> DynBoxedMetric<T> {
+        let entry = self.take_entry();
+        let metric = self.build_pinned(metric);
+
+        DynBoxedMetric::from_pinned(metric, entry)
+    }
+
+    /// Build a [`DynPinnedMetric`] for use with this builder.
+    ///
+    /// In order to register it you will likely want to call [`take_entry`] in
+    /// order to extract the [`MetricEntry`] for this metric first.
+    ///
+    /// [`take_entry`]: MetricBuilder::take_entry
+    pub fn build_pinned<T: Metric>(mut self, metric: T) -> DynPinnedMetric<T> {
+        self.provider.insert(Metadata::new(self.metadata));
+        self.provider.insert(FormattingFn(self.formatter));
+
+        DynPinnedMetric::new_v2(metric, std::mem::take(&mut self.provider))
     }
 }
 
@@ -135,35 +163,28 @@ pub(crate) fn unregister(metric: *const dyn Metric) {
     REGISTRY.write().unregister(metric);
 }
 
-/// Ensures that the metric `M` has a unique address.
-///
-/// The correctness of the registry depends on each dynamic address having a
-/// unique address. However, we don't want to unconditionally add padding to
-/// all metrics. The way to work around this is to union M with a type of size
-/// 1. That way, if M is a zero-sized type then the storage will have a size
-/// of 1 but otherwise it has the size of M.
-union PinnedMetricStorage<M> {
-    metric: ManuallyDrop<M>,
-    _padding: u8,
+/// A metric combined with a set of dynamic providers.
+struct ProviderMetric<M> {
+    metric: M,
+    provider: ProviderMap,
 }
 
-impl<M> PinnedMetricStorage<M> {
-    fn new(metric: M) -> Self {
-        Self {
-            metric: ManuallyDrop::new(metric),
-        }
+impl<M: Metric> Metric for ProviderMetric<M> {
+    fn is_enabled(&self) -> bool {
+        self.metric.is_enabled()
     }
 
-    #[inline]
-    fn metric(&self) -> &M {
-        // Safety: nothing ever accesses _padding
-        unsafe { &self.metric }
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        self.metric.as_any()
     }
-}
 
-impl<M> Drop for PinnedMetricStorage<M> {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.metric) }
+    fn value(&self) -> Option<crate::Value> {
+        self.metric.value()
+    }
+
+    fn provide<'a>(&'a self, request: &mut crate::Request<'a>) {
+        self.provider.provide(request);
+        self.metric.provide(request);
     }
 }
 
@@ -189,10 +210,7 @@ impl<M> Drop for PinnedMetricStorage<M> {
 ///
 /// [`register`]: crate::dynmetrics::DynPinnedMetric::register
 pub struct DynPinnedMetric<M: Metric> {
-    storage: PinnedMetricStorage<M>,
-    // This type relies on Pin's guarantees for correctness. Allowing it to be unpinned would cause
-    // errors.
-    _marker: PhantomPinned,
+    metric: ProviderMetric<M>,
 }
 
 impl<M: Metric> DynPinnedMetric<M> {
@@ -202,9 +220,12 @@ impl<M: Metric> DynPinnedMetric<M> {
     ///
     /// [`register`]: self::DynPinnedMetric::register
     pub fn new(metric: M) -> Self {
+        Self::new_v2(metric, ProviderMap::new())
+    }
+
+    fn new_v2(metric: M, provider: ProviderMap) -> Self {
         Self {
-            storage: PinnedMetricStorage::new(metric),
-            _marker: PhantomPinned,
+            metric: ProviderMetric { metric, provider },
         }
     }
 
@@ -213,7 +234,7 @@ impl<M: Metric> DynPinnedMetric<M> {
     /// Calling this multiple times will result in the same metric being
     /// registered multiple times under potentially different names.
     pub fn register(self: Pin<&Self>, mut entry: MetricEntry) {
-        entry.metric = self.storage.metric();
+        entry.metric = &self.metric;
 
         // SAFETY:
         // To prove that this is safe we need to list out a few guarantees/requirements:
@@ -237,7 +258,7 @@ impl<M: Metric> DynPinnedMetric<M> {
 impl<M: Metric> Drop for DynPinnedMetric<M> {
     fn drop(&mut self) {
         // If this metric has not been registered then nothing will be removed.
-        unregister(self.storage.metric());
+        unregister(&self.metric);
     }
 }
 
@@ -246,7 +267,7 @@ impl<M: Metric> Deref for DynPinnedMetric<M> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.storage.metric()
+        &self.metric.metric
     }
 }
 
@@ -273,6 +294,13 @@ impl<M: Metric> DynBoxedMetric<M> {
     /// provided `name`.
     pub fn new(metric: M, entry: MetricEntry) -> Self {
         let this = Self::unregistered(metric);
+        this.register(entry);
+        this
+    }
+
+    fn from_pinned(metric: DynPinnedMetric<M>, entry: MetricEntry) -> Self {
+        let metric = Box::pin(metric);
+        let this = Self { metric };
         this.register(entry);
         this
     }

--- a/metriken-core/src/lib.rs
+++ b/metriken-core/src/lib.rs
@@ -68,6 +68,9 @@ pub trait Metric: Send + Sync + 'static {
     /// This can be used in conjunction with [`Request::provide_value`] and
     /// [`Request::provide_ref`] to extract references to member variables from
     /// `dyn Metric` trait objects.
+    ///
+    /// If you want to read provided types from a metric see
+    /// [`MetricEntry::request_value`] and [`MetricEntry::request_ref`].
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         // Silence the unused variable warning.
         let _ = request;
@@ -97,8 +100,6 @@ pub struct MetricEntry {
     metric: *const dyn Metric,
     name: Cow<'static, str>,
     description: Option<Cow<'static, str>>,
-    metadata: Metadata,
-    formatter: fn(&Self, Format) -> String,
 }
 
 impl MetricEntry {
@@ -119,12 +120,18 @@ impl MetricEntry {
 
     /// Access the [`Metadata`] associated with this metrics entry.
     pub fn metadata(&self) -> &Metadata {
-        &self.metadata
+        static EMPTY: Metadata = Metadata::default_const();
+        self.request_ref::<Metadata>().unwrap_or(&EMPTY)
     }
 
     /// Format the metric into a string with the given format.
     pub fn formatted(&self, format: Format) -> String {
-        (self.formatter)(self, format)
+        let formatter = self
+            .request_value::<crate::wrapper::FormattingFn>()
+            .map(|func| func.0)
+            .unwrap_or(crate::default_formatter);
+
+        formatter(self, format)
     }
 
     /// Checks whether `metric` is the metric for this entry.
@@ -142,7 +149,12 @@ impl MetricEntry {
         a == b
     }
 
-    /// Request a value of type `T` from metric.
+    /// Request a value of type `T` from the metric.
+    ///
+    /// This will succeed if the metric's [`provide`] implementation called
+    /// [`Request::provide_value`] with a value of type `T`.
+    ///
+    /// [`provide`]: Metric::provide
     pub fn request_value<T>(&self) -> Option<T>
     where
         T: 'static,
@@ -150,7 +162,12 @@ impl MetricEntry {
         crate::request_value(self.metric())
     }
 
-    /// Request a reference of type `T` from metric.
+    /// Request a reference of type `T` from the metric.
+    ///
+    /// This will succeed if the metric's [`provide`] implementation called
+    /// [`Request::provide_ref`] with a value of type `T`.
+    ///
+    /// [`provide`]: Metric::provide
     pub fn request_ref<T>(&self) -> Option<&T>
     where
         T: ?Sized + 'static,
@@ -188,6 +205,8 @@ pub mod export {
     pub extern crate linkme;
     pub extern crate phf;
 
+    pub use crate::wrapper::*;
+
     #[linkme::distributed_slice]
     pub static METRICS: [crate::MetricEntry] = [..];
 
@@ -195,8 +214,6 @@ pub mod export {
         metric: &'static dyn Metric,
         name: &'static str,
         description: Option<&'static str>,
-        metadata: &'static phf::Map<&'static str, &'static str>,
-        formatter: fn(&crate::MetricEntry, crate::Format) -> String,
     ) -> crate::MetricEntry {
         use std::borrow::Cow;
 
@@ -207,9 +224,11 @@ pub mod export {
                 Some(desc) => Some(Cow::Borrowed(desc)),
                 None => None,
             },
-            metadata: Metadata::new_static(metadata),
-            formatter,
         }
+    }
+
+    pub const fn metadata(metadata: &'static phf::Map<&'static str, &'static str>) -> Metadata {
+        Metadata::new_static(metadata)
     }
 }
 
@@ -226,17 +245,28 @@ macro_rules! declare_metric_v1 {
         const _: () = {
             use $crate::export::phf;
 
-            static __METADATA: $crate::export::phf::Map<&'static str, &'static str> =
+            static __METADATA_MAP: $crate::export::phf::Map<&'static str, &'static str> =
                 $crate::export::phf::phf_map! { $( $key => $value, )* };
+            static __METADATA: $crate::Metadata = $crate::export::metadata(&__METADATA_MAP);
+
+            // We use this to inject some provided values into metric itself
+            // without having to use up extra memory storing anything.
+            struct MetricProvider;
+
+            impl $crate::export::InjectedProvider for MetricProvider {
+                fn provide(request: &mut $crate::Request<'_>) {
+                    request
+                        .provide_ref(&__METADATA)
+                        .provide_value($crate::export::FormattingFn($formatter));
+                }
+            }
 
             #[$crate::export::linkme::distributed_slice($crate::export::METRICS)]
             #[linkme(crate = $crate::export::linkme)]
             static __ENTRY: $crate::MetricEntry = $crate::export::entry_v1(
-                &$metric,
+                $crate::export::MetricWrapper::<_, MetricProvider>::from_ref(&$metric),
                 $name,
                 $description,
-                &__METADATA,
-                $formatter
             );
         };
     }

--- a/metriken-core/src/provide.rs
+++ b/metriken-core/src/provide.rs
@@ -1,0 +1,230 @@
+//! This module is a copy of a subset of the APIs available in `core::error`.
+
+use std::any::TypeId;
+
+use crate::Metric;
+
+/// Request a value of type `T` from the given `impl Metric`.
+pub fn request_value<'a, T>(metric: &'a (impl Metric + ?Sized)) -> Option<T>
+where
+    T: 'static,
+{
+    request_by_type_tag::<'a, tags::Value<T>>(metric)
+}
+
+/// Request a reference of type `T` from the given `impl Metric`.
+pub fn request_ref<'a, T>(metric: &'a (impl Metric + ?Sized)) -> Option<&'a T>
+where
+    T: ?Sized + 'static,
+{
+    request_by_type_tag::<'a, tags::Ref<tags::MaybeSizedValue<T>>>(metric)
+}
+
+fn request_by_type_tag<'a, I>(metric: &'a (impl Metric + ?Sized)) -> Option<I::Reified>
+where
+    I: tags::Type<'a>,
+{
+    let mut tagged = TaggedOption::<'a, I>(None);
+    metric.provide(tagged.as_request());
+    tagged.0
+}
+
+/// `Request` supports generic, type-driven access to data.
+///
+/// This struct is based off the unstable `error_generic_member_access` feature
+/// in std.
+#[repr(transparent)]
+pub struct Request<'a>(dyn Erased<'a>);
+
+impl<'a> Request<'a> {
+    fn new<'b>(erased: &'b mut (dyn Erased<'a> + 'a)) -> &'b mut Request<'a> {
+        // SAFETY: transmuting `&mut (dyn Erased<'a> + 'a)` to `&mut
+        //         Request<'a>` is safe because `Request` is
+        //         `#[repr(transparent)]`.
+        unsafe { &mut *(erased as *mut dyn Erased<'a> as *mut Request<'a>) }
+    }
+
+    /// Provide a value or other type with only static lifetimes.
+    pub fn provide_value<T>(&mut self, value: T) -> &mut Self
+    where
+        T: 'static,
+    {
+        self.provide::<tags::Value<T>>(value)
+    }
+
+    /// Provide a value or other type with only static lifetimes computed using
+    /// a closure.
+    pub fn provide_value_with<T>(&mut self, fulfil: impl FnOnce() -> T) -> &mut Self
+    where
+        T: 'static,
+    {
+        self.provide_with::<tags::Value<T>>(fulfil)
+    }
+
+    /// Provide a reference. The referee type must be bounded by `'static`,
+    /// but may be unsized.
+    pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self {
+        self.provide::<tags::Ref<tags::MaybeSizedValue<T>>>(value)
+    }
+
+    /// Provide a reference computed using a closure. The referee type
+    /// must be bounded by `'static`, but may be unsized.
+    pub fn provide_ref_with<T: ?Sized + 'static>(
+        &mut self,
+        fulfil: impl FnOnce() -> &'a T,
+    ) -> &mut Self {
+        self.provide_with::<tags::Ref<tags::MaybeSizedValue<T>>>(fulfil)
+    }
+
+    /// Provide a value for the given `Type` tag.
+    fn provide<I>(&mut self, value: I::Reified) -> &mut Self
+    where
+        I: tags::Type<'a>,
+    {
+        self.provide_with::<I>(move || value)
+    }
+
+    /// Provide a value with the given `Type` tag, using a closure to prevent
+    /// unnecessary work.
+    fn provide_with<I>(&mut self, fulfil: impl FnOnce() -> I::Reified) -> &mut Self
+    where
+        I: tags::Type<'a>,
+    {
+        if let Some(res @ TaggedOption(None)) = self.0.downcast_mut::<I>() {
+            res.0 = Some(fulfil());
+        }
+
+        self
+    }
+
+    /// Check if the `Request` would be satisfied if provided with a
+    /// value of the specified type. If the type does not match or has
+    /// already been provided, returns false.
+    pub fn would_be_satisfied_by_value_of<T>(&self) -> bool
+    where
+        T: 'static,
+    {
+        self.would_be_satisfied_by::<tags::Value<T>>()
+    }
+
+    /// Check if the `Request` would be satisfied if provided with a
+    /// reference to a value of the specified type. If the type does
+    /// not match or has already been provided, returns false.
+    pub fn would_be_satisfied_by_ref_of<T>(&self) -> bool
+    where
+        T: ?Sized + 'static,
+    {
+        self.would_be_satisfied_by::<tags::Ref<tags::MaybeSizedValue<T>>>()
+    }
+
+    fn would_be_satisfied_by<I>(&self) -> bool
+    where
+        I: tags::Type<'a>,
+    {
+        matches!(self.0.downcast::<I>(), Some(TaggedOption(None)))
+    }
+}
+
+mod tags {
+    //! Type tags are used to identify a type using a separate value. This
+    //! module includes type tags for some very common types.
+
+    use std::marker::PhantomData;
+
+    /// This trait is implemented by specific tag types in order to allow
+    /// describing a type which can be requested for a given lifetime `'a`.
+    pub(crate) trait Type<'a>: Sized + 'static {
+        type Reified: 'a;
+    }
+
+    /// Similar to the [`Type`] trait, but for a type which may be unsized.
+    pub(crate) trait MaybeSizedType<'a>: Sized + 'static {
+        type Reified: ?Sized + 'a;
+    }
+
+    impl<'a, T: Type<'a>> MaybeSizedType<'a> for T {
+        type Reified = T;
+    }
+
+    /// Type-based tag for types bounded by `'static`.
+    #[derive(Debug)]
+    pub(crate) struct Value<T: 'static>(PhantomData<T>);
+
+    impl<'a, T: 'static> Type<'a> for Value<T> {
+        type Reified = T;
+    }
+
+    /// Type-based tag similar to [`Value`] but which may be unsized (i.e., has
+    /// a `?Sized` bound).
+    #[derive(Debug)]
+    pub(crate) struct MaybeSizedValue<T: ?Sized + 'static>(PhantomData<T>);
+
+    impl<'a, T: ?Sized + 'static> MaybeSizedType<'a> for MaybeSizedValue<T> {
+        type Reified = T;
+    }
+
+    pub(crate) struct Ref<I>(PhantomData<I>);
+
+    impl<'a, I: MaybeSizedType<'a>> Type<'a> for Ref<I> {
+        type Reified = &'a I::Reified;
+    }
+}
+
+/// An `Option` with a type tag `I`.
+///
+/// Since this struct implements `Erased`, the type can be erased to make a
+/// dynamically typed option. The type can be checked dynamically using
+/// `Erased::tag_id` and since this is statically checked for the concrete type,
+/// there is some degree of type safety.
+#[repr(transparent)]
+pub(crate) struct TaggedOption<'a, I: tags::Type<'a>>(pub Option<I::Reified>);
+
+impl<'a, I: tags::Type<'a>> TaggedOption<'a, I> {
+    pub(crate) fn as_request(&mut self) -> &mut Request<'a> {
+        Request::new(self as &mut (dyn Erased<'a> + 'a))
+    }
+}
+
+/// Represents a type-erased but identifiable object.
+///
+/// This trait is exclusively implemented by the `TaggedOption` type.
+unsafe trait Erased<'a>: 'a {
+    /// The `TypeId` of the erased type.
+    fn tag_id(&self) -> TypeId;
+}
+
+unsafe impl<'a, I: tags::Type<'a>> Erased<'a> for TaggedOption<'a, I> {
+    fn tag_id(&self) -> TypeId {
+        TypeId::of::<I>()
+    }
+}
+
+impl<'a> dyn Erased<'a> + 'a {
+    /// Returns a reference to the dynamic value if it is tagged with `I` or
+    /// `None` otherwise.
+    fn downcast<I>(&self) -> Option<&TaggedOption<'a, I>>
+    where
+        I: tags::Type<'a>,
+    {
+        if self.tag_id() == TypeId::of::<I>() {
+            // SAFETY: We just checked whether we're pointing to an I
+            Some(unsafe { &*(self as *const Self).cast::<TaggedOption<'a, I>>() })
+        } else {
+            None
+        }
+    }
+
+    /// Returns a mutable reference to the dynamic value if it is tagged with
+    /// `I` or `None` otherwise.
+    fn downcast_mut<I>(&mut self) -> Option<&mut TaggedOption<'a, I>>
+    where
+        I: tags::Type<'a>,
+    {
+        if self.tag_id() == TypeId::of::<I>() {
+            // SAFETY: Just checked whether we're pointing to an I.
+            Some(unsafe { &mut *(self as *mut Self).cast::<TaggedOption<'a, I>>() })
+        } else {
+            None
+        }
+    }
+}

--- a/metriken-core/src/provide.rs
+++ b/metriken-core/src/provide.rs
@@ -2,6 +2,7 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use crate::Metric;
 
@@ -255,6 +256,10 @@ impl ProviderMap {
         TypeId::of::<tags::Ref<T>>()
     }
 }
+
+// Needed so that DynBoxedMetric and DynPinnedMetric both implement these.
+impl UnwindSafe for ProviderMap {}
+impl RefUnwindSafe for ProviderMap {}
 
 pub(crate) trait Provide: Any + Send + Sync + 'static {
     fn provide<'a>(&'a self, request: &mut Request<'a>);

--- a/metriken-core/src/provide.rs
+++ b/metriken-core/src/provide.rs
@@ -190,6 +190,9 @@ impl<'a, I: tags::Type<'a>> TaggedOption<'a, I> {
 /// Represents a type-erased but identifiable object.
 ///
 /// This trait is exclusively implemented by the `TaggedOption` type.
+///
+/// # Safety
+/// The `TypeId` returned by `tag_id` _must_ be the type id of the tagged type.
 unsafe trait Erased<'a>: 'a {
     /// The `TypeId` of the erased type.
     fn tag_id(&self) -> TypeId;

--- a/metriken-core/src/wrapper.rs
+++ b/metriken-core/src/wrapper.rs
@@ -1,0 +1,65 @@
+use std::marker::PhantomData;
+
+use crate::{Format, Metric, MetricEntry, Request};
+
+/// A helper trait for use with [`MetricWrapper`] that allows for injecting
+/// additional provided values.
+///
+/// This is used by the [`declare_metric_v1`][0] macro to provide certain
+/// built-in types for the metric.
+///
+/// [0]: crate::declare_metric_v1
+pub trait InjectedProvider: Send + Sync + 'static {
+    fn provide(request: &mut Request<'_>);
+}
+
+/// A wrapper around a metric that injects a few more values into the request
+/// via the [`InjectedProvider`] `P`.
+///
+/// This allows us to use the provider for some types that are internal to this
+/// crate.
+#[repr(transparent)]
+pub struct MetricWrapper<M, P> {
+    metric: M,
+    provider: PhantomData<P>,
+}
+
+impl<M, P> MetricWrapper<M, P> {
+    pub const fn new(metric: M) -> Self {
+        Self {
+            metric,
+            provider: PhantomData,
+        }
+    }
+
+    pub const fn from_ref(metric: &M) -> &Self {
+        // SAFETY: We are #[repr(transparent)] so this is safe.
+        unsafe { &*(metric as *const M as *const Self) }
+    }
+}
+
+impl<M, P> Metric for MetricWrapper<M, P>
+where
+    M: Metric,
+    P: InjectedProvider,
+{
+    fn is_enabled(&self) -> bool {
+        self.metric.is_enabled()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        self.metric.as_any()
+    }
+
+    fn value(&self) -> Option<crate::Value> {
+        self.metric.value()
+    }
+
+    fn provide<'a>(&'a self, request: &mut Request<'a>) {
+        <P as InjectedProvider>::provide(request);
+        self.metric.provide(request)
+    }
+}
+
+/// Metric provider type that wraps around a formatting function.
+pub struct FormattingFn(pub fn(&MetricEntry, Format) -> String);

--- a/metriken/tests/dynmetrics.rs
+++ b/metriken/tests/dynmetrics.rs
@@ -59,8 +59,7 @@ fn pinned_scope() {
     let _guard = TestGuard::new();
 
     {
-        let (metric, entry) = MetricBuilder::new("pinned_scope")
-            .build_pinned(Counter::new());
+        let (metric, entry) = MetricBuilder::new("pinned_scope").build_pinned(Counter::new());
 
         let metric = unsafe { Pin::new_unchecked(&metric) };
         metric.register(entry);
@@ -75,7 +74,9 @@ fn pinned_dup_register() {
     let _guard = TestGuard::new();
 
     {
-        let metric = MetricBuilder::new("pinned_dup").build_pinned(Counter::new()).0;
+        let metric = MetricBuilder::new("pinned_dup")
+            .build_pinned(Counter::new())
+            .0;
         let metric = unsafe { Pin::new_unchecked(&metric) };
         metric.register(MetricBuilder::new("pinned_dup_1").into_entry());
         metric.register(MetricBuilder::new("pinned_dup_2").into_entry());


### PR DESCRIPTION
Currently, if we have metrics that want to use custom formatting for a specific exposition format then the only way to do this is for the metric in question to set `formatter = <some formatting function>`. However, as is, formatting functions have a whole bunch of disadvantages:
- They are not extensible. The only way to add support for new crates is to modify `metriken-core` itself to add new variants to the `Format` enum.
- They are stringly typed. The formatting function only returns a string so to make change in, for example, how all prometheus metrics are formatted we need to modify _all_ the formatting functions.

More generally, they couple `metriken` and `metriken-core` to specific exposition formats which contradicts metriken's design goals.

That being said, they are useful and metriken does not currently provide an alternate way for its users to specify how they should be formatted. They also cannot be removed outright as they are part of the public API of `metriken-core` and I am not willing to release a new major version of `metriken-core` at this time.

This PR provides an alternative way to go about things. It adds a few new APIs which are modeled after similar unstable types that are being added to `std::error`. The main changes are:
- `Metric` gets a new `provide` method that looks like this
  ```rust
  fn provide<'a>(&self, request: &mut Request<'a>) {}
  ```
- There is now a `Request` type. It has `provide_value` and `provide_ref` methods.
- `MetricEntry` now has `request_value` and `request_ref` methods which call `Metric::provide` and return one of the provided values, if one was provided with the requested type.

Now, if an exposition crate wants some custom metadata from its metrics we follow the steps below:
- The exposition crate declares its own metadata type (e.g. `struct PrometheusName { .. }`)
- Individual metrics can choose to provide said metadata (`request.provide_value(PrometheusName { .. })`)
- The exposition crate can then read back that metadata via `entry.request_value::<PrometheusName>()`

None of these steps require metriken to know about the `PrometheusName` type.

There is still some work to be done to make this fully usable on the metriken side (e.g. the `#[metric]` macro should allow you to specify types to provide) but the core bit here is done. The rest will happen in a future PR.