### PR TITLE
Add a step to deduplicate cargo warnings

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -78,11 +78,12 @@ jobs:
       - uses: swlynch99/cargo-sweep-action@v1
       - uses: taiki-e/install-action@v2
         with:
-          tool: clippy-sarif,sarif-fmt
+          tool: clippy-sarif,sarif-fmt,cargo-deduplicate-warnings
 
       - name: cargo clippy
         run: |
           cargo clippy --all-targets --all-features --message-format json \
+            | cargo deduplicate-warnings \
             | clippy-sarif      \
             | tee clippy.sarif  \
             | sarif-fmt


### PR DESCRIPTION
clippy-sarif will emit duplicate warnings cargo does. We don't want that so this adds a new step to deduplicate the warnings before that.