### PR TITLE
add new exposition crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
@@ -103,6 +104,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
 dependencies = [
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +39,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "equivalent"
@@ -57,6 +107,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +144,15 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -109,6 +191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +231,26 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "metriken-exposition"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "histogram",
+ "metriken",
+ "serde",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -205,7 +312,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -228,18 +335,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -282,22 +389,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -336,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -371,7 +478,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -413,6 +520,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,12 +605,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
 ]
 
 [[package]]
@@ -458,13 +628,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -474,10 +659,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -486,10 +683,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -498,16 +707,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ members = [
     "metriken",
     "metriken-core",
     "metriken-derive"
-]
+, "metriken-exposition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ resolver = "2"
 members = [
     "metriken",
     "metriken-core",
-    "metriken-derive"
-, "metriken-exposition"]
+    "metriken-derive",
+    "metriken-exposition"
+]

--- a/metriken-core/src/metrics.rs
+++ b/metriken-core/src/metrics.rs
@@ -6,8 +6,8 @@ use parking_lot::RwLockReadGuard;
 use crate::dynmetrics::DynMetricsRegistry;
 use crate::MetricEntry;
 
-/// The list of all metrics registered via the either `#[metric]` attribute or by
-/// using the types within the [`dynmetrics`] module.
+/// The list of all metrics registered via the either `#[metric]` attribute or
+/// by using the types within the [`dynmetrics`] module.
 ///
 /// Names within metrics are not guaranteed to be unique and no aggregation of
 /// metrics with the same name is done.

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -18,4 +18,4 @@ metriken = { version = "0.5.1", path = "../metriken" }
 serde = { version = "1.0.196", features = ["derive"], optional = true }
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "chrono/serde", "histogram/serde"]

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -7,6 +7,9 @@ authors = [
     "Sean Lynch <sean@iop.systems>",
 ]
 license = "MIT OR Apache-2.0"
+description = "Exposition for metriken metrics"
+homepage = "https://github.com/iopsystems/metriken"
+repository = "https://github.com/iopsystems/metriken"
 
 [dependencies]
 chrono = "0.4.34"

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "metriken-exposition"
+version = "0.1.0"
+edition = "2021"
+authors = [
+    "Brian Martin <brian@iop.systems>",
+    "Sean Lynch <sean@iop.systems>",
+]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+chrono = "0.4.34"
+histogram = "0.9.1"
+metriken = { version = "0.5.1", path = "../metriken" }
+serde = { version = "1.0.196", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -1,0 +1,11 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+pub use histogram::Snapshot as HistogramSnapshot;
+use metriken::{AtomicHistogram, RwLockHistogram, Value};
+
+mod snapshot;
+mod snapshotter;
+
+pub use snapshot::Snapshot;
+pub use snapshotter::{Snapshotter, SnapshotterBuilder};

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -1,4 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
 pub use histogram::Snapshot as HistogramSnapshot;

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -1,3 +1,8 @@
+//! Exposition of Metriken metrics
+//!
+//! Provides a standardized struct for a snapshot of the metric readings as well
+//! as a way of producing the snapshots.
+
 use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -3,11 +3,7 @@
 //! Provides a standardized struct for a snapshot of the metric readings as well
 //! as a way of producing the snapshots.
 
-use std::time::SystemTime;
-
-use chrono::{DateTime, Utc};
 pub use histogram::Snapshot as HistogramSnapshot;
-use metriken::{AtomicHistogram, RwLockHistogram, Value};
 
 mod snapshot;
 mod snapshotter;

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -1,13 +1,18 @@
 use crate::*;
 
+// TODO(bmartin): derive Debug for Snapshot once the histogram snapshot has its
+// own debug impl.
+
 /// Contains a snapshot of metric readings.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
+#[non_exhaustive]
 pub struct Snapshot {
-    datetime: DateTime<Utc>,
-    systemtime: SystemTime,
-    pub(crate) counters: Vec<(String, u64)>,
-    pub(crate) gauges: Vec<(String, i64)>,
-    pub(crate) histograms: Vec<(String, HistogramSnapshot)>,
+    pub datetime: DateTime<Utc>,
+    pub systemtime: SystemTime,
+    pub counters: Vec<(String, u64)>,
+    pub gauges: Vec<(String, i64)>,
+    pub histograms: Vec<(String, HistogramSnapshot)>,
 }
 
 impl Snapshot {

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -1,4 +1,8 @@
-use crate::*;
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+
+use crate::HistogramSnapshot;
 
 // TODO(bmartin): derive Debug for Snapshot once the histogram snapshot has its
 // own debug impl.

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -1,0 +1,52 @@
+use crate::*;
+
+/// Contains a snapshot of metric readings.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Snapshot {
+    datetime: DateTime<Utc>,
+    unix_ns: u128,
+    pub(crate) counters: Vec<(String, u64)>,
+    pub(crate) gauges: Vec<(String, i64)>,
+    pub(crate) histograms: Vec<(String, HistogramSnapshot)>,
+}
+
+impl Snapshot {
+    pub fn datetime(&self) -> DateTime<Utc> {
+        self.datetime
+    }
+
+    pub fn unix_ns(&self) -> u128 {
+        self.unix_ns
+    }
+
+    pub fn counters(&self) -> &[(String, u64)] {
+        &self.counters
+    }
+
+    pub fn gauges(&self) -> &[(String, i64)] {
+        &self.gauges
+    }
+
+    pub fn histograms(&self) -> &[(String, HistogramSnapshot)] {
+        &self.histograms
+    }
+}
+
+impl Snapshot {
+    pub(crate) fn new() -> Self {
+        let datetime: DateTime<Utc> = Utc::now();
+
+        let unix_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        Self {
+            datetime,
+            unix_ns,
+            counters: Vec::new(),
+            gauges: Vec::new(),
+            histograms: Vec::new(),
+        }
+    }
+}

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -4,29 +4,35 @@ use crate::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Snapshot {
     datetime: DateTime<Utc>,
-    unix_ns: u128,
+    unix_ns: u64,
     pub(crate) counters: Vec<(String, u64)>,
     pub(crate) gauges: Vec<(String, i64)>,
     pub(crate) histograms: Vec<(String, HistogramSnapshot)>,
 }
 
 impl Snapshot {
+    /// The UTC datetime when the snapshot was created.
     pub fn datetime(&self) -> DateTime<Utc> {
         self.datetime
     }
 
-    pub fn unix_ns(&self) -> u128 {
+    /// The number of whole nanoseconds since the UNIX epoch when the snapshot
+    /// was created.
+    pub fn unix_ns(&self) -> u64 {
         self.unix_ns
     }
 
+    /// A view into the counters for this snapshot.
     pub fn counters(&self) -> &[(String, u64)] {
         &self.counters
     }
 
+    /// A view into the gauges for this snapshot.
     pub fn gauges(&self) -> &[(String, i64)] {
         &self.gauges
     }
 
+    /// A view into the histograms for this snapshot.
     pub fn histograms(&self) -> &[(String, HistogramSnapshot)] {
         &self.histograms
     }
@@ -39,7 +45,7 @@ impl Snapshot {
         let unix_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_nanos();
+            .as_nanos() as u64;
 
         Self {
             datetime,

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -4,7 +4,7 @@ use crate::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Snapshot {
     datetime: DateTime<Utc>,
-    unix_ns: u64,
+    systemtime: SystemTime,
     pub(crate) counters: Vec<(String, u64)>,
     pub(crate) gauges: Vec<(String, i64)>,
     pub(crate) histograms: Vec<(String, HistogramSnapshot)>,
@@ -16,10 +16,9 @@ impl Snapshot {
         self.datetime
     }
 
-    /// The number of whole nanoseconds since the UNIX epoch when the snapshot
-    /// was created.
-    pub fn unix_ns(&self) -> u64 {
-        self.unix_ns
+    /// The system time when the snapshot was created.
+    pub fn systemtime(&self) -> SystemTime {
+        self.systemtime
     }
 
     /// A view into the counters for this snapshot.
@@ -40,16 +39,12 @@ impl Snapshot {
 
 impl Snapshot {
     pub(crate) fn new() -> Self {
-        let datetime: DateTime<Utc> = Utc::now();
-
-        let unix_ns = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64;
+        let now = SystemTime::now();
+        let datetime = DateTime::<Utc>::from(now);
 
         Self {
             datetime,
-            unix_ns,
+            systemtime: now,
             counters: Vec::new(),
             gauges: Vec::new(),
             histograms: Vec::new(),

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -113,8 +113,7 @@ impl Snapshotter {
                                 .histograms
                                 .push((metric.formatted(metriken::Format::Simple), histogram));
                         }
-                    }
-                    if let Some(histogram) = other.downcast_ref::<RwLockHistogram>() {
+                    } else if let Some(histogram) = other.downcast_ref::<RwLockHistogram>() {
                         if !self.rwlock_histograms {
                             continue;
                         }

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+
 use crate::*;
 
 /// Produces a snapshot of metric readings.
@@ -62,7 +63,7 @@ impl Snapshotter {
                 continue;
             }
 
-            if ! (self.kind_filter)(metric.as_any()) {
+            if !(self.kind_filter)(metric.as_any()) {
                 continue;
             }
 

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+/// Produces a snapshot of metric readings.
 pub struct Snapshotter {
     counters: bool,
     gauges: bool,
@@ -8,35 +9,51 @@ pub struct Snapshotter {
     filter: fn(&str) -> bool,
 }
 
+/// Used to build a new `Snapshotter`.
+#[derive(Default)]
 pub struct SnapshotterBuilder {
     snapshotter: Snapshotter,
 }
 
 impl SnapshotterBuilder {
+    /// Construct a new builder. By default, all metric types are enabled and no
+    /// filtering is applied.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Consume the builder and return a `Snapshotter`.
     pub fn build(self) -> Snapshotter {
         self.snapshotter
     }
 
+    /// Allow disabling the inclusion of counter metrics from the snapshot.
     pub fn counters(mut self, included: bool) -> Self {
         self.snapshotter.counters = included;
         self
     }
 
+    /// Allow disabling the inclusion of gauge metrics from the snapshot.
     pub fn gauges(mut self, included: bool) -> Self {
         self.snapshotter.gauges = included;
         self
     }
 
+    /// Allow disabling the inclusion of `AtomicHistogram`s from the snapshot.
     pub fn atomic_histograms(mut self, included: bool) -> Self {
         self.snapshotter.atomic_histograms = included;
         self
     }
 
+    /// Allow disabling the inclusion of `RwLockHistogram`s from the snapshot.
     pub fn rwlock_histograms(mut self, included: bool) -> Self {
         self.snapshotter.rwlock_histograms = included;
         self
     }
 
+    /// Allow a user-supplied filtering function to be applied. The function is
+    /// given the metric name and must return true for any metric that should
+    /// be included in the snapshot.
     pub fn filter(mut self, filter: fn(&str) -> bool) -> Self {
         self.snapshotter.filter = filter;
         self
@@ -56,6 +73,7 @@ impl Default for Snapshotter {
 }
 
 impl Snapshotter {
+    /// Produce a new snapshot.
     pub fn snapshot(&self) -> Snapshot {
         let mut snapshot = Snapshot::new();
 

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -1,0 +1,117 @@
+use crate::*;
+
+pub struct Snapshotter {
+    counters: bool,
+    gauges: bool,
+    atomic_histograms: bool,
+    rwlock_histograms: bool,
+    filter: fn(&str) -> bool,
+}
+
+pub struct SnapshotterBuilder {
+    snapshotter: Snapshotter,
+}
+
+impl SnapshotterBuilder {
+    pub fn build(self) -> Snapshotter {
+        self.snapshotter
+    }
+
+    pub fn counters(mut self, included: bool) -> Self {
+        self.snapshotter.counters = included;
+        self
+    }
+
+    pub fn gauges(mut self, included: bool) -> Self {
+        self.snapshotter.gauges = included;
+        self
+    }
+
+    pub fn atomic_histograms(mut self, included: bool) -> Self {
+        self.snapshotter.atomic_histograms = included;
+        self
+    }
+
+    pub fn rwlock_histograms(mut self, included: bool) -> Self {
+        self.snapshotter.rwlock_histograms = included;
+        self
+    }
+
+    pub fn filter(mut self, filter: fn(&str) -> bool) -> Self {
+        self.snapshotter.filter = filter;
+        self
+    }
+}
+
+impl Default for Snapshotter {
+    fn default() -> Self {
+        Self {
+            counters: true,
+            gauges: true,
+            atomic_histograms: true,
+            rwlock_histograms: true,
+            filter: |_| true,
+        }
+    }
+}
+
+impl Snapshotter {
+    pub fn snapshot(&self) -> Snapshot {
+        let mut snapshot = Snapshot::new();
+
+        // iterate through the metrics and build-up the snapshot
+        for metric in &metriken::metrics() {
+            if !(self.filter)(metric.name()) {
+                continue;
+            }
+
+            match metric.value() {
+                Some(Value::Counter(value)) => {
+                    if !self.counters {
+                        continue;
+                    }
+
+                    snapshot
+                        .counters
+                        .push((metric.formatted(metriken::Format::Simple), value));
+                }
+                Some(Value::Gauge(value)) => {
+                    if !self.gauges {
+                        continue;
+                    }
+
+                    snapshot
+                        .gauges
+                        .push((metric.formatted(metriken::Format::Simple), value));
+                }
+                Some(Value::Other(other)) => {
+                    if let Some(histogram) = other.downcast_ref::<AtomicHistogram>() {
+                        if !self.atomic_histograms {
+                            continue;
+                        }
+
+                        if let Some(histogram) = histogram.snapshot() {
+                            snapshot
+                                .histograms
+                                .push((metric.formatted(metriken::Format::Simple), histogram));
+                        }
+                    }
+                    if let Some(histogram) = other.downcast_ref::<RwLockHistogram>() {
+                        if !self.rwlock_histograms {
+                            continue;
+                        }
+
+                        if let Some(histogram) = histogram.snapshot() {
+                            snapshot
+                                .histograms
+                                .push((metric.formatted(metriken::Format::Simple), histogram));
+                        }
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        snapshot
+    }
+}

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -34,8 +34,8 @@ impl SnapshotterBuilder {
     }
 
     /// Allow a user-supplied filtering function to be applied. The function is
-    /// given the metric name and must return true for any metric that should
-    /// be included in the snapshot.
+    /// given the metric as an `Any` and must return true for any metric that
+    /// should be included in the snapshot.
     pub fn kind_filter(mut self, filter: fn(Option<&dyn std::any::Any>) -> bool) -> Self {
         self.snapshotter.kind_filter = filter;
         self

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -1,12 +1,10 @@
+use std::any::Any;
 use crate::*;
 
 /// Produces a snapshot of metric readings.
 pub struct Snapshotter {
-    counters: bool,
-    gauges: bool,
-    atomic_histograms: bool,
-    rwlock_histograms: bool,
-    filter: fn(&str) -> bool,
+    kind_filter: fn(Option<&dyn Any>) -> bool,
+    name_filter: fn(&str) -> bool,
 }
 
 /// Used to build a new `Snapshotter`.
@@ -27,35 +25,19 @@ impl SnapshotterBuilder {
         self.snapshotter
     }
 
-    /// Allow disabling the inclusion of counter metrics from the snapshot.
-    pub fn counters(mut self, included: bool) -> Self {
-        self.snapshotter.counters = included;
-        self
-    }
-
-    /// Allow disabling the inclusion of gauge metrics from the snapshot.
-    pub fn gauges(mut self, included: bool) -> Self {
-        self.snapshotter.gauges = included;
-        self
-    }
-
-    /// Allow disabling the inclusion of `AtomicHistogram`s from the snapshot.
-    pub fn atomic_histograms(mut self, included: bool) -> Self {
-        self.snapshotter.atomic_histograms = included;
-        self
-    }
-
-    /// Allow disabling the inclusion of `RwLockHistogram`s from the snapshot.
-    pub fn rwlock_histograms(mut self, included: bool) -> Self {
-        self.snapshotter.rwlock_histograms = included;
+    /// Allow a user-supplied filtering function to be applied based on the
+    /// metric name. The function is given the metric name and must return true
+    /// for any metric that should be included in the snapshot.
+    pub fn name_filter(mut self, filter: fn(&str) -> bool) -> Self {
+        self.snapshotter.name_filter = filter;
         self
     }
 
     /// Allow a user-supplied filtering function to be applied. The function is
     /// given the metric name and must return true for any metric that should
     /// be included in the snapshot.
-    pub fn filter(mut self, filter: fn(&str) -> bool) -> Self {
-        self.snapshotter.filter = filter;
+    pub fn kind_filter(mut self, filter: fn(Option<&dyn std::any::Any>) -> bool) -> Self {
+        self.snapshotter.kind_filter = filter;
         self
     }
 }
@@ -63,11 +45,8 @@ impl SnapshotterBuilder {
 impl Default for Snapshotter {
     fn default() -> Self {
         Self {
-            counters: true,
-            gauges: true,
-            atomic_histograms: true,
-            rwlock_histograms: true,
-            filter: |_| true,
+            kind_filter: |_| true,
+            name_filter: |_| true,
         }
     }
 }
@@ -79,45 +58,33 @@ impl Snapshotter {
 
         // iterate through the metrics and build-up the snapshot
         for metric in &metriken::metrics() {
-            if !(self.filter)(metric.name()) {
+            if !(self.name_filter)(metric.name()) {
+                continue;
+            }
+
+            if ! (self.kind_filter)(metric.as_any()) {
                 continue;
             }
 
             match metric.value() {
                 Some(Value::Counter(value)) => {
-                    if !self.counters {
-                        continue;
-                    }
-
                     snapshot
                         .counters
                         .push((metric.formatted(metriken::Format::Simple), value));
                 }
                 Some(Value::Gauge(value)) => {
-                    if !self.gauges {
-                        continue;
-                    }
-
                     snapshot
                         .gauges
                         .push((metric.formatted(metriken::Format::Simple), value));
                 }
                 Some(Value::Other(other)) => {
                     if let Some(histogram) = other.downcast_ref::<AtomicHistogram>() {
-                        if !self.atomic_histograms {
-                            continue;
-                        }
-
                         if let Some(histogram) = histogram.snapshot() {
                             snapshot
                                 .histograms
                                 .push((metric.formatted(metriken::Format::Simple), histogram));
                         }
                     } else if let Some(histogram) = other.downcast_ref::<RwLockHistogram>() {
-                        if !self.rwlock_histograms {
-                            continue;
-                        }
-
                         if let Some(histogram) = histogram.snapshot() {
                             snapshot
                                 .histograms


### PR DESCRIPTION
Adds the start of an exposition crate which provides a type for holding a snapshot of the current metric values and a type that can produce snapshots which may optionally be filtered down to a subset of the registered metrics.

This gives us a single place to have a serializable snapshot type and in the future can be extended to include additional exposition related functionality.