### PR TITLE
adds key-value metadata to snapshots

### DIFF
--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -117,7 +117,7 @@ impl ParquetSchema {
 
     /// Finalize the schema and build a `ParquetWriter`.
     pub fn finalize(
-        mut self,
+        self,
         writer: impl Write + Send,
         options: ParquetOptions,
     ) -> Result<ParquetWriter<impl Write + Send>, ParquetError> {

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -190,7 +190,7 @@ impl ParquetSchema {
         } else {
             Some(
                 self.metadata
-                    .drain()
+                    .into_iter()
                     .map(|(key, value)| KeyValue {
                         key,
                         value: Some(value),

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -9,7 +9,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
-use parquet::format::FileMetaData;
+use parquet::format::{FileMetaData, KeyValue};
 
 use crate::snapshot::{HashedSnapshot, Snapshot};
 use crate::HistogramSnapshot;
@@ -79,6 +79,7 @@ pub struct ParquetSchema {
     gauges: BTreeMap<String, Vec<Option<i64>>>,
     histograms: BTreeMap<String, Vec<Option<HistogramSnapshot>>>,
     summary_percentiles: Option<Vec<f64>>,
+    metadata: HashMap<String, String>,
 }
 
 impl ParquetSchema {
@@ -88,6 +89,7 @@ impl ParquetSchema {
             gauges: BTreeMap::new(),
             histograms: BTreeMap::new(),
             summary_percentiles: percentiles,
+            metadata: HashMap::new(),
         }
     }
 
@@ -107,11 +109,15 @@ impl ParquetSchema {
         for h in histograms {
             self.histograms.entry(h.0).or_default();
         }
+
+        if self.metadata.is_empty() && !snapshot.metadata.is_empty() {
+            self.metadata = snapshot.metadata;
+        }
     }
 
     /// Finalize the schema and build a `ParquetWriter`.
     pub fn finalize(
-        self,
+        mut self,
         writer: impl Write + Send,
         options: ParquetOptions,
     ) -> Result<ParquetWriter<impl Write + Send>, ParquetError> {
@@ -179,9 +185,24 @@ impl ParquetSchema {
             }
         }
 
+        let metadata: Option<Vec<KeyValue>> = if self.metadata.is_empty() {
+            None
+        } else {
+            Some(
+                self.metadata
+                    .drain()
+                    .map(|(key, value)| KeyValue {
+                        key,
+                        value: Some(value),
+                    })
+                    .collect(),
+            )
+        };
+
         let schema = Arc::new(Schema::new(fields));
         let props = WriterProperties::builder()
             .set_compression(options.compression)
+            .set_key_value_metadata(metadata)
             .build();
         let arrow_writer = ArrowWriter::try_new(writer, schema.clone(), Some(props))?;
 

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -17,7 +17,10 @@ use crate::HistogramSnapshot;
 #[non_exhaustive]
 pub struct Snapshot {
     pub systemtime: SystemTime,
+
+    #[cfg_attr(feature = "serde", serde(default))]
     pub metadata: HashMap<String, String>,
+
     pub counters: Vec<(String, u64)>,
     pub gauges: Vec<(String, i64)>,
     pub histograms: Vec<(String, HistogramSnapshot)>,

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "parquet")]
 use std::collections::HashMap;
 use std::time::SystemTime;
 
@@ -18,6 +17,7 @@ use crate::HistogramSnapshot;
 #[non_exhaustive]
 pub struct Snapshot {
     pub systemtime: SystemTime,
+    pub metadata: HashMap<String, String>,
     pub counters: Vec<(String, u64)>,
     pub gauges: Vec<(String, i64)>,
     pub histograms: Vec<(String, HistogramSnapshot)>,
@@ -35,6 +35,7 @@ impl Snapshot {
     pub(crate) fn new() -> Self {
         Self {
             systemtime: SystemTime::now(),
+            metadata: HashMap::new(),
             counters: Vec::new(),
             gauges: Vec::new(),
             histograms: Vec::new(),
@@ -44,6 +45,11 @@ impl Snapshot {
     /// The system time when the snapshot was created.
     pub fn systemtime(&self) -> SystemTime {
         self.systemtime
+    }
+
+    /// Fetch the value for a snapshot metadata key.
+    pub fn get_metadata(&self, key: &str) -> Option<&str> {
+        self.metadata.get(key).map(|x| x.as_str())
     }
 
     /// A view into the counters for this snapshot.


### PR DESCRIPTION
Adds the ability to store key-value metadata in the snapshots and will embed that metadata into the parquet file.