### PR TITLE
refactor snapshots to use structs instead of tuples

### DIFF
--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -16,5 +16,5 @@ mod snapshotter;
 pub use convert::MsgpackToParquet;
 #[cfg(feature = "parquet")]
 pub use parquet::{ParquetOptions, ParquetSchema, ParquetWriter};
-pub use snapshot::Snapshot;
+pub use snapshot::{Counter, Gauge, Histogram, Snapshot};
 pub use snapshotter::{Snapshotter, SnapshotterBuilder};

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -99,15 +99,15 @@ impl ParquetSchema {
             (snapshot.counters, snapshot.gauges, snapshot.histograms);
 
         for counter in counters {
-            self.counters.entry(counter.0).or_default();
+            self.counters.entry(counter.name).or_default();
         }
 
         for gauge in gauges {
-            self.gauges.entry(gauge.0).or_default();
+            self.gauges.entry(gauge.name).or_default();
         }
 
         for h in histograms {
-            self.histograms.entry(h.0).or_default();
+            self.histograms.entry(h.name).or_default();
         }
 
         if self.metadata.is_empty() && !snapshot.metadata.is_empty() {
@@ -256,15 +256,15 @@ impl<W: Write + Send> ParquetWriter<W> {
         // `None` if a metric in the schema does not exist in the snapshot gaps
         // are automatically filled without additional handling.
         for (key, v) in self.counters.iter_mut() {
-            v.push(hs.counters.remove(key));
+            v.push(hs.counters.remove(key).map(|v| v.value));
         }
 
         for (key, v) in self.gauges.iter_mut() {
-            v.push(hs.gauges.remove(key));
+            v.push(hs.gauges.remove(key).map(|v| v.value));
         }
 
         for (key, v) in self.histograms.iter_mut() {
-            v.push(hs.histograms.remove(key));
+            v.push(hs.histograms.remove(key).map(|v| v.value));
         }
 
         // Check and flush if the max batch size of rows have been processed


### PR DESCRIPTION
To have extensibility going forward and to be able to add metadata to the metric snapshots, this change refactors the snapshots to use structs for counters, gauges, and histograms instead of using name-value tuples.

This is a breaking change, but should reduce the need for breaking changes going forward.