### PR TITLE
exposition: add per-column metadata to parquet format

### DIFF
--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.196", features = ["derive"], optional = true }
 serde_json = { version = "1.0.114", optional = true }
 
 [features]
+default = ["parquet"]
 serde = ["dep:serde", "chrono/serde", "histogram/serde"]
 json = ["dep:serde", "dep:serde_json"]
 msgpack = ["dep:serde", "dep:rmp-serde"]

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0.196", features = ["derive"], optional = true }
 serde_json = { version = "1.0.114", optional = true }
 
 [features]
-default = ["parquet"]
 serde = ["dep:serde", "chrono/serde", "histogram/serde"]
 json = ["dep:serde", "dep:serde_json"]
 msgpack = ["dep:serde", "dep:rmp-serde"]

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -152,7 +152,7 @@ impl ParquetSchema {
             fields
                 .push(Field::new(counter.clone(), DataType::UInt64, true).with_metadata(metadata));
 
-            // push the counter name into the counters vec
+            // initialize storage for the counter values
             counters.insert(counter, Vec::with_capacity(self.rows));
         }
 
@@ -166,7 +166,7 @@ impl ParquetSchema {
             // add column to schema
             fields.push(Field::new(gauge.clone(), DataType::Int64, true).with_metadata(metadata));
 
-            // push the gauge name into the gauges vec
+            // initialize storage for the gauge values
             gauges.insert(gauge, Vec::with_capacity(self.rows));
         }
 
@@ -212,7 +212,7 @@ impl ParquetSchema {
                 }
             }
 
-            // push the histogram name into the histograms vec
+            // initialize storage for the histogram values
             histograms.insert(histogram, Vec::with_capacity(self.rows));
         }
 

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -143,10 +143,8 @@ impl ParquetSchema {
             let mut metadata = metadata.take().unwrap_or(HashMap::new());
             metadata.insert("metric_type".to_string(), "counter".to_string());
 
-            fields.push(
-                Field::new(counter.clone(), DataType::UInt64, true)
-                    .with_metadata(metadata),
-            );
+            fields
+                .push(Field::new(counter.clone(), DataType::UInt64, true).with_metadata(metadata));
         }
 
         // Create one column field per-gauge
@@ -155,10 +153,7 @@ impl ParquetSchema {
             let mut metadata = metadata.take().unwrap_or(HashMap::new());
             metadata.insert("metric_type".to_string(), "gauge".to_string());
 
-            fields.push(
-                Field::new(gauge.clone(), DataType::Int64, true)
-                    .with_metadata(metadata),
-            );
+            fields.push(Field::new(gauge.clone(), DataType::Int64, true).with_metadata(metadata));
         }
 
         // Create at least three column fields per-snapshot: two for
@@ -219,17 +214,23 @@ impl ParquetSchema {
             .build();
         let arrow_writer = ArrowWriter::try_new(writer, schema.clone(), Some(props))?;
 
-        let counters = self.counters.into_keys().map(|k| {
-            (k, Vec::with_capacity(self.rows))
-        }).collect();
+        let counters = self
+            .counters
+            .into_keys()
+            .map(|k| (k, Vec::with_capacity(self.rows)))
+            .collect();
 
-        let gauges = self.gauges.into_keys().map(|k| {
-            (k, Vec::with_capacity(self.rows))
-        }).collect();
+        let gauges = self
+            .gauges
+            .into_keys()
+            .map(|k| (k, Vec::with_capacity(self.rows)))
+            .collect();
 
-        let histograms = self.histograms.into_keys().map(|k| {
-            (k, Vec::with_capacity(self.rows))
-        }).collect();
+        let histograms = self
+            .histograms
+            .into_keys()
+            .map(|k| (k, Vec::with_capacity(self.rows)))
+            .collect();
 
         Ok(ParquetWriter {
             writer: arrow_writer,

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -101,15 +101,15 @@ impl ParquetSchema {
             (snapshot.counters, snapshot.gauges, snapshot.histograms);
 
         for counter in counters {
-            self.counters.entry(counter.name).or_default();
+            self.counters.entry(counter.name).or_insert(Some(counter.metadata));
         }
 
         for gauge in gauges {
-            self.gauges.entry(gauge.name).or_default();
+            self.gauges.entry(gauge.name).or_insert(Some(gauge.metadata));
         }
 
-        for h in histograms {
-            self.histograms.entry(h.name).or_default();
+        for histogram in histograms {
+            self.histograms.entry(histogram.name).or_insert(Some(histogram.metadata));
         }
 
         if self.metadata.is_empty() && !snapshot.metadata.is_empty() {

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -101,7 +101,9 @@ impl ParquetSchema {
             (snapshot.counters, snapshot.gauges, snapshot.histograms);
 
         for counter in counters {
-            self.counters.entry(counter.name).or_insert(counter.metadata);
+            self.counters
+                .entry(counter.name)
+                .or_insert(counter.metadata);
         }
 
         for gauge in gauges {
@@ -109,7 +111,9 @@ impl ParquetSchema {
         }
 
         for histogram in histograms {
-            self.histograms.entry(histogram.name).or_insert(histogram.metadata);
+            self.histograms
+                .entry(histogram.name)
+                .or_insert(histogram.metadata);
         }
 
         if self.metadata.is_empty() && !snapshot.metadata.is_empty() {
@@ -183,8 +187,12 @@ impl ParquetSchema {
                     .with_metadata(metadata.clone()),
             );
             fields.push(
-                Field::new(format!("{histogram}:max_config_power"), DataType::UInt8, true)
-                    .with_metadata(metadata.clone()),
+                Field::new(
+                    format!("{histogram}:max_config_power"),
+                    DataType::UInt8,
+                    true,
+                )
+                .with_metadata(metadata.clone()),
             );
             fields.push(
                 Field::new(

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -153,7 +153,7 @@ impl ParquetSchema {
                 .push(Field::new(counter.clone(), DataType::UInt64, true).with_metadata(metadata));
 
             // push the counter name into the counters vec
-            counters.push(counter.clone());
+            counters.push(counter);
         }
 
         let mut gauges = Vec::with_capacity(self.gauges.len());


### PR DESCRIPTION
Adds per-column metadata to the parquet format by merging the metric metadata with the annoations we need for type information.