### PR TITLE
update histogram crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,9 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "histogram"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
+checksum = "f4d3bddd75a32b17e75762f128ffc7a33158b933b6eb27424da9be4a58f30eb9"
 dependencies = [
  "serde",
  "thiserror",
@@ -700,7 +700,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "metriken"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "chrono",

--- a/metriken-core/Cargo.toml
+++ b/metriken-core/Cargo.toml
@@ -23,5 +23,5 @@ parking_lot = "0.12"
 phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
-metriken = { version = "0.5", path = "../metriken" }
+metriken = { version = "0.6", path = "../metriken" }
 

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -14,8 +14,8 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = { version = "50.0.0", optional = true }
 chrono = "0.4.34"
-histogram = "0.9.1"
-metriken = { version = "0.5.1", path = "../metriken" }
+histogram = "0.10.0"
+metriken = { version = "0.6.0", path = "../metriken" }
 parquet = { version = "50.0.0", optional = true }
 rmp-serde = { version = "1.1.2", optional = true }
 serde = { version = "1.0.196", features = ["derive"], optional = true }

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -3,8 +3,6 @@
 //! Provides a standardized struct for a snapshot of the metric readings as well
 //! as a way of producing the snapshots.
 
-pub use histogram::Snapshot as HistogramSnapshot;
-
 #[cfg(all(feature = "serde", feature = "msgpack", feature = "parquet"))]
 mod convert;
 #[cfg(feature = "parquet")]

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use arrow::array::*;
 use arrow::datatypes::*;
 use arrow::error::ArrowError;
+use histogram::Histogram;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::errors::ParquetError;
@@ -12,7 +13,6 @@ use parquet::file::properties::WriterProperties;
 use parquet::format::{FileMetaData, KeyValue};
 
 use crate::snapshot::{HashedSnapshot, Snapshot};
-use crate::HistogramSnapshot;
 
 /// Options for `ParquetWriter` controlling the output parquet file.
 #[derive(Clone, Debug)]
@@ -252,7 +252,7 @@ pub struct ParquetWriter<W: Write + Send> {
     gauges: BTreeMap<String, Vec<Option<i64>>>,
 
     /// Schema-ordered columnar data for histograms
-    histograms: BTreeMap<String, Vec<Option<HistogramSnapshot>>>,
+    histograms: BTreeMap<String, Vec<Option<Histogram>>>,
 
     /// Summary percentiles to store for histograms
     summary_percentiles: Option<Vec<f64>>,

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -6,8 +6,6 @@ use rmp_serde::encode::Error as SerializeMsgpackError;
 #[cfg(feature = "json")]
 use serde_json::Error as JsonError;
 
-use crate::HistogramSnapshot;
-
 // TODO(bmartin): derive Debug for Snapshot once the histogram snapshot has its
 // own debug impl.
 
@@ -34,7 +32,7 @@ pub struct Gauge {
 #[non_exhaustive]
 pub struct Histogram {
     pub name: String,
-    pub value: HistogramSnapshot,
+    pub value: histogram::Histogram,
     pub metadata: HashMap<String, String>,
 }
 

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -97,9 +97,9 @@ impl Snapshotter {
                 Some(Value::Other(other)) => {
                     let histogram = if let Some(histogram) = other.downcast_ref::<AtomicHistogram>()
                     {
-                        histogram.snapshot()
+                        histogram.load()
                     } else if let Some(histogram) = other.downcast_ref::<RwLockHistogram>() {
-                        histogram.snapshot()
+                        histogram.load()
                     } else {
                         None
                     };

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Brian Martin <brian@iop.systems>", "Sean Lynch <sean@iop.systems>"]
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 metriken-core   = { version = "0.1",    path = "../metriken-core" }
 metriken-derive = { version = "=0.5.1", path = "../metriken-derive" }
 
-histogram = "0.9.0"
+histogram = "0.10.0"
 once_cell = "1.14.0"
 parking_lot = "0.12.1"
 

--- a/metriken/src/histogram.rs
+++ b/metriken/src/histogram.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-pub use histogram::{Bucket, Config, Error, Snapshot};
+pub use histogram::{Bucket, Config, Error, Histogram};
 use parking_lot::RwLock;
 
 use crate::{Metric, Value};
@@ -48,9 +48,10 @@ impl AtomicHistogram {
         self.config
     }
 
-    /// Create a new snapshot from the histogram.
-    pub fn snapshot(&self) -> Option<Snapshot> {
-        self.inner.get().map(|h| h.snapshot())
+    /// Loads and returns the histogram. Returns `None` if the histogram has
+    /// never been incremented.
+    pub fn load(&self) -> Option<Histogram> {
+        self.inner.get().map(|h| h.load())
     }
 
     fn get_or_init(&self) -> &::histogram::AtomicHistogram {
@@ -121,9 +122,10 @@ impl RwLockHistogram {
         self.config
     }
 
-    /// Create a new snapshot from the histogram.
-    pub fn snapshot(&self) -> Option<Snapshot> {
-        self.inner.get().map(|h| h.read().snapshot())
+    /// Loads and returns the histogram. Returns `None` if the histogram has
+    /// never been incremented.
+    pub fn load(&self) -> Option<Histogram> {
+        self.inner.get().map(|h| h.read().clone())
     }
 
     fn get_or_init(&self) -> &RwLock<::histogram::Histogram> {


### PR DESCRIPTION
The histogram crate has been updated to remove the Snapshot type and generally simplify the crate.

This change updates the histogram crate and makes the necessary changes to metriken to use histogram 0.10.0