### PR TITLE
feat: allow further customization of msgpack converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "chrono",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-exposition/src/convert.rs
+++ b/metriken-exposition/src/convert.rs
@@ -8,17 +8,9 @@ use crate::snapshot::Snapshot;
 use crate::{ParquetOptions, ParquetSchema};
 
 /// A struct for converting msgpack'd metriken snapshots into a parquet file.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MsgpackToParquet {
     parquet_options: ParquetOptions,
-}
-
-impl Default for MsgpackToParquet {
-    fn default() -> Self {
-        Self {
-            parquet_options: ParquetOptions::new().compression_level(3).unwrap(),
-        }
-    }
 }
 
 impl MsgpackToParquet {

--- a/metriken-exposition/src/convert.rs
+++ b/metriken-exposition/src/convert.rs
@@ -7,27 +7,32 @@ use parquet::errors::ParquetError;
 use crate::snapshot::Snapshot;
 use crate::{ParquetOptions, ParquetSchema};
 
+/// A struct for converting msgpack'd metriken snapshots into a parquet file.
 #[derive(Clone, Debug)]
 pub struct MsgpackToParquet {
-    compression_level: i32,
+    parquet_options: ParquetOptions,
 }
 
 impl Default for MsgpackToParquet {
     fn default() -> Self {
         Self {
-            compression_level: 3,
+            parquet_options: ParquetOptions::new().compression_level(3).unwrap()
         }
     }
 }
 
 impl MsgpackToParquet {
+    /// Returns a new `MsgpackToParquet` converter that uses the default
+    /// conversion options.
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn compression_level(mut self, level: i32) -> Self {
-        self.compression_level = level;
-        self
+    /// Create a `MsgpackToParquet` converted from the provided parquet options.
+    pub fn with_options(options: ParquetOptions) -> Self {
+        Self {
+            parquet_options: options,
+        }
     }
 
     /// Converts a file with metrics in msgpack format to a parquet file.
@@ -62,7 +67,7 @@ impl MsgpackToParquet {
         }
         let mut writer = schema.finalize(
             writer,
-            ParquetOptions::new().compression_level(self.compression_level)?,
+            self.parquet_options,
         )?;
 
         // Rewind file pointer and second pass for the actual metrics

--- a/metriken-exposition/src/convert.rs
+++ b/metriken-exposition/src/convert.rs
@@ -16,7 +16,7 @@ pub struct MsgpackToParquet {
 impl Default for MsgpackToParquet {
     fn default() -> Self {
         Self {
-            parquet_options: ParquetOptions::new().compression_level(3).unwrap()
+            parquet_options: ParquetOptions::new().compression_level(3).unwrap(),
         }
     }
 }
@@ -65,10 +65,7 @@ impl MsgpackToParquet {
                 .map_err(|x| ParquetError::External(Box::new(x)))?;
             schema.push(s);
         }
-        let mut writer = schema.finalize(
-            writer,
-            self.parquet_options,
-        )?;
+        let mut writer = schema.finalize(writer, self.parquet_options)?;
 
         // Rewind file pointer and second pass for the actual metrics
         reader.rewind().unwrap();

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -14,6 +14,9 @@ use parquet::format::{FileMetaData, KeyValue};
 
 use crate::snapshot::{HashedSnapshot, Snapshot};
 
+const DEFAULT_COMPRESSION: Compression = Compression::UNCOMPRESSED;
+const DEFAULT_MAX_BATCH_SIZE: usize = 1024 * 1024;
+
 /// Options for `ParquetWriter` controlling the output parquet file.
 #[derive(Clone, Debug)]
 pub struct ParquetOptions {
@@ -24,16 +27,23 @@ pub struct ParquetOptions {
 }
 
 impl ParquetOptions {
+    /// Create a new set of `ParquetOption` with the default values
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the compression level for the parquet file. The default is no
+    /// compression. Set the compression level to a corresponding zstd level to
+    /// enable compression.
     pub fn compression_level(mut self, level: i32) -> Result<Self, ParquetError> {
         let compression = Compression::ZSTD(ZstdLevel::try_new(level)?);
         self.compression = compression;
         Ok(self)
     }
 
+    /// Sets the number of rows to be cache in memory before being written as a
+    /// `RecordBatch`. Large values have better performance at the cost of
+    /// additional memory usage. The default is ~1M rows (2^20).
     pub fn max_batch_size(mut self, batch_size: usize) -> Self {
         self.max_batch_size = batch_size;
         self
@@ -43,8 +53,8 @@ impl ParquetOptions {
 impl Default for ParquetOptions {
     fn default() -> Self {
         Self {
-            compression: Compression::UNCOMPRESSED,
-            max_batch_size: 1024 * 1024,
+            compression: DEFAULT_COMPRESSION,
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
         }
     }
 }

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -35,7 +35,7 @@ impl Compression {
     /// error if the level is not a valid zstd compression level.
     pub fn zstd(level: i32) -> Result<Self, ParquetError> {
         Ok(Self {
-            inner: ParquetCompression::ZSTD(ZstdLevel::try_new(level)?)
+            inner: ParquetCompression::ZSTD(ZstdLevel::try_new(level)?),
         })
     }
 }


### PR DESCRIPTION
Allows for further customization of the MsgpackToParquet converter by taking a `ParquetOptions` in the `with_options` constructor.