### PR TITLE
exposition: store histograms as either a List or a LargeList

### DIFF
--- a/metriken-exposition/src/convert.rs
+++ b/metriken-exposition/src/convert.rs
@@ -49,7 +49,7 @@ impl MsgpackToParquet {
         writer: impl Write + Send,
     ) -> Result<i64, ParquetError> {
         let mut reader = BufReader::new(reader);
-        let mut schema = ParquetSchema::new(None);
+        let mut schema = ParquetSchema::new();
 
         // First pass to build the schema
         while !reader.fill_buf().unwrap().is_empty() {


### PR DESCRIPTION
Add configuration parameters so that the output parquet file stores the
nested lists within histograms as either a regular list (i32-indexed;
limited to 2^31 entries) or a large list (i64-indexed; limited to 2^61
entries). Also, remove summary percentiles, as summaries of free-running
histograms are not particularly useful.