### PR TITLE
exposition: remove optional summary percentiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "chrono",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-exposition/src/convert.rs
+++ b/metriken-exposition/src/convert.rs
@@ -49,7 +49,7 @@ impl MsgpackToParquet {
         writer: impl Write + Send,
     ) -> Result<i64, ParquetError> {
         let mut reader = BufReader::new(reader);
-        let mut schema = ParquetSchema::new(None);
+        let mut schema = ParquetSchema::new();
 
         // First pass to build the schema
         while !reader.fill_buf().unwrap().is_empty() {


### PR DESCRIPTION
The histograms stored in the parquet file are free-running. Extracting
summary statistics for each time window from free-running histograms
is not particularly useful, so remove the option altogether.