### PR TITLE
exposition: impose row group limit for parquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "flatbuffers"
 version = "23.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +774,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1073,6 +1096,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1205,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -21,6 +21,9 @@ rmp-serde = { version = "1.1.2", optional = true }
 serde = { version = "1.0.196", features = ["derive"], optional = true }
 serde_json = { version = "1.0.114", optional = true }
 
+[dev-dependencies]
+tempfile = "3.10.1"
+
 [features]
 serde = ["dep:serde", "chrono/serde", "histogram/serde"]
 json = ["dep:serde", "dep:serde_json"]

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -14,7 +14,7 @@ mod snapshotter;
 pub use convert::MsgpackToParquet;
 #[cfg(feature = "parquet")]
 pub use parquet::{
-    ParquetCompression, ParquetHistogramStorage, ParquetOptions, ParquetSchema, ParquetWriter,
+    ParquetCompression, ParquetHistogramType, ParquetOptions, ParquetSchema, ParquetWriter,
 };
 pub use snapshot::{Counter, Gauge, Histogram, Snapshot};
 pub use snapshotter::{Snapshotter, SnapshotterBuilder};

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -71,7 +71,7 @@ impl ParquetOptions {
     /// Sets the compression level for the parquet file. The default is no
     /// compression. Set the compression level to a corresponding zstd level to
     /// enable compression.
-    pub fn with_compression(mut self, compression: ParquetCompression) -> Self {
+    pub fn set_compression(mut self, compression: ParquetCompression) -> Self {
         self.compression = compression;
         self
     }
@@ -79,14 +79,14 @@ impl ParquetOptions {
     /// Sets the number of rows to be cache in memory before being written as a
     /// `RecordBatch`. Large values have better performance at the cost of
     /// additional memory usage. The default is ~1M rows (2^20).
-    pub fn with_max_batch_size(mut self, batch_size: usize) -> Self {
+    pub fn set_max_batch_size(mut self, batch_size: usize) -> Self {
         self.max_batch_size = batch_size;
         self
     }
 
     /// Sets the type for histogram data: standard or sparse. The default is
     /// the standard (dense) histogram.
-    pub fn with_histogram_type(mut self, histogram: ParquetHistogramType) -> Self {
+    pub fn set_histogram_type(mut self, histogram: ParquetHistogramType) -> Self {
         self.histogram_type = histogram;
         self
     }
@@ -247,7 +247,7 @@ impl ParquetSchema {
                 }
                 ParquetHistogramType::Sparse => {
                     // merge metric annotations into the metric metadata
-                    metadata.insert("metric_type".to_string(), "sparse histogram".to_string());
+                    metadata.insert("metric_type".to_string(), "sparse_histogram".to_string());
 
                     fields.push(
                         Field::new(
@@ -500,7 +500,7 @@ mod tests {
     #[test]
     fn test_row_groups() {
         let snapshots = build_snapshots();
-        let tmpfile = write_parquet(snapshots, ParquetOptions::new().with_max_batch_size(1));
+        let tmpfile = write_parquet(snapshots, ParquetOptions::new().set_max_batch_size(1));
         let builder = ParquetRecordBatchReaderBuilder::try_new(tmpfile).unwrap();
 
         // Check row groups
@@ -547,7 +547,7 @@ mod tests {
         let snapshots = build_snapshots();
         let tmpfile = write_parquet(
             snapshots,
-            ParquetOptions::new().with_histogram_type(ParquetHistogramType::Sparse),
+            ParquetOptions::new().set_histogram_type(ParquetHistogramType::Sparse),
         );
         let builder = ParquetRecordBatchReaderBuilder::try_new(tmpfile).unwrap();
 

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -479,7 +479,7 @@ mod tests {
             .finalize(tmpfile.try_clone().unwrap(), options)
             .unwrap();
         for s in &snapshots {
-            let _ = writer.push(s.clone()).unwrap();
+            let _ = writer.push(s.clone());
         }
         let _ = writer.finalize();
 


### PR DESCRIPTION
Remove internal buffering from the ParquetWriter and instead
write single snapshots to the ArrowWriter which buffers data
internally until the row group size limit is reached. Set
the row group limit for the ArrowWriter from the specified
batch size in the ParquetOptions. Finally, reduce the default
row group size from 1M to 50K.