### PR TITLE
deps: update histogram and bump version numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "histogram"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd81cb9a629d0a868f2092937332fca5fd985971d2155bf6fcc225ef8a6be2c"
+checksum = "b62b8d85713ddc62e5e78db13bf9f9305610d0419276faa845076a68b7165872"
 dependencies = [
  "serde",
  "thiserror",
@@ -732,7 +732,7 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "metriken"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrow",
  "chrono",

--- a/metriken-core/Cargo.toml
+++ b/metriken-core/Cargo.toml
@@ -23,5 +23,5 @@ parking_lot = "0.12"
 phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
-metriken = { version = "0.6", path = "../metriken" }
+metriken = { version = "0.7", path = "../metriken" }
 

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -14,8 +14,8 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = { version = "51.0.0", optional = true }
 chrono = "0.4.34"
-histogram = "0.10.0"
-metriken = { version = "0.6.0", path = "../metriken" }
+histogram = "0.11.0"
+metriken = { version = "0.7.0", path = "../metriken" }
 parquet = { version = "51.0.0", optional = true }
 rmp-serde = { version = "1.1.2", optional = true }
 serde = { version = "1.0.196", features = ["derive"], optional = true }

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Brian Martin <brian@iop.systems>", "Sean Lynch <sean@iop.systems>"]
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 metriken-core   = { version = "0.1",    path = "../metriken-core" }
 metriken-derive = { version = "=0.5.1", path = "../metriken-derive" }
 
-histogram = "0.10.0"
+histogram = "0.11.0"
 once_cell = "1.14.0"
 parking_lot = "0.12.1"
 


### PR DESCRIPTION
Update metriken to use histogram 0.11.0. This is a breaking change,
which modifies the interface to the functions to look-up percentiles.