### PR TITLE
Fix missing metrics metadata for dyn metrics

### DIFF
--- a/metriken/tests/dynmetrics.rs
+++ b/metriken/tests/dynmetrics.rs
@@ -99,3 +99,21 @@ fn multi_metric() {
     drop(m2);
     assert_eq!(metrics().dynamic_metrics().len(), 0);
 }
+
+#[test]
+fn read_metadata() {
+    let _guard = TestGuard::new();
+
+    let _metric = MetricBuilder::new("metric1")
+        .metadata("foo", "b")
+        .metadata("bar", "c")
+        .build(Counter::new());
+
+    let metrics = metrics();
+    assert_eq!(metrics.dynamic_metrics().len(), 1);
+    let entry = metrics.dynamic_metrics().next().unwrap();
+
+    assert_eq!(entry.name(), "metric1");
+    assert_eq!(entry.metadata().get("foo"), Some("b"));
+    assert_eq!(entry.metadata().get("bar"), Some("c"));
+}


### PR DESCRIPTION
There were two issues here that needed to be fixed:
1. `ProviderMap` was using the wrong type to find the element, and,
2. Downcasting was done using the autogenerated `Provide` impl for `Box<dyn Provide>` instead of calling the provide method on `dyn Provide`.

This commit fixes both and then adds a set of test cases to ensure that things keep working in the future.