### PR TITLE
fix(query): fallback to column name when metric label missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -124,7 +124,7 @@ impl Tsdb {
                 let name = if let Some(n) = meta.get("metric").cloned() {
                     n
                 } else {
-                    continue;
+                    field.name().to_string()
                 };
 
                 let grouping_power: Option<Result<u8, ParseIntError>> =

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -61,10 +61,10 @@ impl Tsdb {
             .unwrap_or(1000);
         data.sampling_interval_ms = interval;
 
-        data.source = match metadata.get("source").map(|v| v.as_str()) {
-            Some("rezolus") => "Rezolus".to_string(),
-            _ => "unknown".to_string(),
-        };
+        data.source = metadata
+            .get("source")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
 
         data.version = match metadata.get("version").map(|v| v.as_str()) {
             Some(s) => s.to_string(),


### PR DESCRIPTION
Adds a fallback to use the column name when the metric label is
missing