### PR TITLE
fix(query): strip :buckets suffix in fallback path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -124,7 +124,13 @@ impl Tsdb {
                 let name = if let Some(n) = meta.get("metric").cloned() {
                     n
                 } else {
-                    field.name().to_string()
+                    let col_name = field.name();
+                    // Strip :buckets suffix from histogram column names
+                    // (e.g., "request_latency:buckets" -> "request_latency")
+                    col_name
+                        .strip_suffix(":buckets")
+                        .unwrap_or(col_name)
+                        .to_string()
                 };
 
                 let grouping_power: Option<Result<u8, ParseIntError>> =


### PR DESCRIPTION
Strip the :buckets suffix in the fallback path so that histogram columns are loaded without it