### PR TITLE
fix(query): histogram_quantile() semantics incorrect

### DIFF
--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -609,6 +609,13 @@ impl QueryEngine {
                         }
                     };
 
+                    if !(0.0..=1.0).contains(&quantile) {
+                        return Err(QueryError::ParseError(format!(
+                            "histogram_quantile quantile must be between 0.0 and 1.0, got {}",
+                            quantile
+                        )));
+                    }
+
                     // Second argument should be a vector selector (histogram metric)
                     let metric_name = match &*call.args.args[1] {
                         Expr::VectorSelector(selector) => {
@@ -1333,6 +1340,15 @@ impl QueryEngine {
             return Err(QueryError::ParseError(
                 "Percentiles array cannot be empty".to_string(),
             ));
+        }
+
+        for &p in &percentiles {
+            if !(0.0..=1.0).contains(&p) {
+                return Err(QueryError::ParseError(format!(
+                    "histogram_percentiles values must be between 0.0 and 1.0, got {}",
+                    p
+                )));
+            }
         }
 
         // Extract the metric selector (everything after the array and comma)

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -378,13 +378,12 @@ impl QueryEngine {
                         {
                             // If we have a filter, use filtered_rate; otherwise get rates for all
                             // series
-                            let rate_collection =
-                                if filter_labels.inner.is_empty() {
-                                    collection.rate() // Get rates for all
-                                                      // series
-                                } else {
-                                    collection.filtered_rate(&filter_labels) // Only calculate rates for matching series
-                                };
+                            let rate_collection = if filter_labels.inner.is_empty() {
+                                collection.rate() // Get rates for all
+                                                  // series
+                            } else {
+                                collection.filtered_rate(&filter_labels) // Only calculate rates for matching series
+                            };
 
                             let start_ns = (start * 1e9) as u64;
                             let end_ns = (end * 1e9) as u64;

--- a/metriken-query/src/tsdb/series/histogram.rs
+++ b/metriken-query/src/tsdb/series/histogram.rs
@@ -42,6 +42,10 @@ impl HistogramSeries {
             return None;
         }
 
+        // Convert from fractional (0.0–1.0) to percentage (0.0–100.0) scale
+        // expected by the histogram crate.
+        let pct_100: Vec<f64> = percentiles.iter().map(|p| p * 100.0).collect();
+
         let (_, mut prev) = self.inner.first_key_value().unwrap();
 
         let mut result = vec![UntypedSeries::default(); percentiles.len()];
@@ -49,7 +53,7 @@ impl HistogramSeries {
         for (time, curr) in self.inner.iter().skip(1) {
             let delta = curr.wrapping_sub(prev).unwrap();
 
-            if let Ok(Some(percentiles)) = delta.percentiles(percentiles) {
+            if let Ok(Some(percentiles)) = delta.percentiles(&pct_100) {
                 for (id, (_, bucket)) in percentiles.iter().enumerate() {
                     result[id].inner.insert(*time, bucket.end() as f64);
                 }


### PR DESCRIPTION
The issue this PR is meant to fix is in Rezolus, with _BlockIO / Size / Write_:

<img width="1498" height="804" alt="image" src="https://github.com/user-attachments/assets/f47570b2-8061-42a6-abc8-f432366797de" />

The fix seems suspicious to me, but Claude says: 

> HistogramSeries::percentiles() receives fractional percentiles
(0.5 = p50) from all three callers (histogram_percentiles, histogram_quantile, and the Tsdb::percentiles API), but the histogram crate's delta.percentiles() expects percentage values (50.0 = p50). The one-line fix multiplies by 100 at this boundary.

I've confirmed that using this branch does seem to fix the underlying issue, but cannot tell whether any regressions have been introduced in the viewer (or elsewhere). @brayniac curious if this is the right place for the fix, vs. a more local fix to the way this crate is used in Rezolus.

On that question, Claude says:

> You could change the dashboard queries from [0.5, 0.9,
>   0.99] to [50, 90, 99], but there are two issues:
> 
>   1. Labels break. handle_histogram_percentiles at line 1376 uses the
>   input values as output labels: metric_labels.insert("percentile",
>   percentiles[idx].to_string()). The viewer's JS likely keys on "0.5",
>   "0.99" etc. to render legend entries. Changing to "50", "99" would need
>   corresponding frontend changes.
>   2. PromQL convention. Standard PromQL's histogram_quantile(0.99, ...)
>   uses the 0–1 scale. The histogram_quantile call path (line 600 in
>   promql/mod.rs) also passes the raw fractional value through to the same
>   HistogramSeries::percentiles(). You can't fix that one from the viewer
>   side since it's a standard PromQL function — users/MCP could call
>   histogram_quantile(0.99, metric) directly.
> 
>   So the fix really belongs in HistogramSeries::percentiles() where it
>   bridges between the PromQL convention (fractional) and the histogram
>   crate convention (percentage). That said — if you'd prefer not to
>   fork/patch metriken-query, you could work around it by changing the
>   query strings to use 50/90/99 and adjusting the label handling, but it'd
>    be messier and wouldn't fix histogram_quantile.

I also asked why only this histogram-based chart failed and the others did not, and it says the others are also showing the wrong quantiles:

> All histogram percentile charts are actually affected — they all return
>   wrong values. But block IO size is where it's visibly broken.
> 
>   With the bug, percentiles [0.5, 0.9, 0.99, 0.999, 0.9999] are
>   interpreted as the 0.5th, 0.9th, 0.99th... percentiles instead of the
>   50th, 90th, 99th. That means "return the value below which 0.5% of
>   observations fall" — essentially the very bottom of the distribution.
> 
>   The difference is bucket 0:
> 
>   - Block IO size: Small or zero-sized I/Os populate bucket 0. When the
>   histogram crate looks for the 0.5th percentile and bucket 0 has any
>   data, the threshold is immediately satisfied → returns 0 for every
>   percentile → flat line at y=0 → invisible on the chart.
>   - Latency metrics (runqueue, syscall, TCP, etc.): Latencies are always >
>    0, so bucket 0 is typically empty. The 0.5th percentile still returns
>   something from whatever the lowest populated bucket is — a small but
>   non-zero value. So you get a visible line, just with incorrect
>   (much-too-low) values. If you compared them to expected latencies,
>   they'd be wrong, but they're not obviously zero/missing.
> 
>   In short: the bug makes all histogram charts show approximately the
>   minimum observed value instead of the true percentile. Block IO size is
>   the canary because its minimum is 0.