### PR TITLE
feat(query): generic QueryEngine, TSDB ingest, and robustness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "arrow",
  "axum",
  "histogram",
+ "metriken-exposition",
  "parquet",
  "promql-parser",
  "serde",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
+metriken-exposition = { path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::ops::Deref;
 use std::sync::Arc;
 
 use promql_parser::parser::token::TokenType;
@@ -81,12 +82,16 @@ pub enum QueryResult {
 }
 
 /// The PromQL query engine
-pub struct QueryEngine {
-    tsdb: Arc<Tsdb>,
+///
+/// Generic over the TSDB handle type. The default (`Arc<Tsdb>`) covers the
+/// common owned case (MCP, tests, file-backed viewer). Pass `&Tsdb` (or any
+/// other `Deref<Target = Tsdb>`) for zero-copy borrowed access.
+pub struct QueryEngine<T: Deref<Target = Tsdb> = Arc<Tsdb>> {
+    tsdb: T,
 }
 
-impl QueryEngine {
-    pub fn new(tsdb: Arc<Tsdb>) -> Self {
+impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
+    pub fn new(tsdb: T) -> Self {
         Self { tsdb }
     }
 
@@ -1481,12 +1486,16 @@ impl QueryEngine {
 
                 let mut min_value = f64::MAX;
                 let mut max_value = f64::MIN;
+                let mut min_bucket_idx = usize::MAX;
+                let mut max_bucket_idx = 0usize;
 
                 for (time_idx, bucket_idx, count) in heatmap_data.data.iter() {
                     if let Some(&new_time_idx) = time_index_map.get(time_idx) {
                         filtered_data.push((new_time_idx, *bucket_idx, *count));
                         min_value = min_value.min(*count);
                         max_value = max_value.max(*count);
+                        min_bucket_idx = min_bucket_idx.min(*bucket_idx);
+                        max_bucket_idx = max_bucket_idx.max(*bucket_idx);
                     }
                 }
 
@@ -1497,11 +1506,26 @@ impl QueryEngine {
                     max_value = 0.0;
                 }
 
+                // Trim bucket_bounds and remap bucket indices to the active range
+                let (trimmed_bounds, trimmed_data) = if !filtered_data.is_empty()
+                    && max_bucket_idx < heatmap_data.bucket_bounds.len()
+                {
+                    let bounds =
+                        heatmap_data.bucket_bounds[min_bucket_idx..=max_bucket_idx].to_vec();
+                    let data = filtered_data
+                        .into_iter()
+                        .map(|(t, b, c)| (t, b - min_bucket_idx, c))
+                        .collect();
+                    (bounds, data)
+                } else {
+                    (heatmap_data.bucket_bounds, filtered_data)
+                };
+
                 return Ok(QueryResult::HistogramHeatmap {
                     result: HistogramHeatmapResult {
                         timestamps: filtered_timestamps,
-                        bucket_bounds: heatmap_data.bucket_bounds,
-                        data: filtered_data,
+                        bucket_bounds: trimmed_bounds,
+                        data: trimmed_data,
                         min_value,
                         max_value,
                     },

--- a/metriken-query/src/tsdb/collection/counter.rs
+++ b/metriken-query/src/tsdb/collection/counter.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Represents a collection of counter timeseries keyed on label sets.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CounterCollection {
     inner: HashMap<Labels, CounterSeries>,
 }

--- a/metriken-query/src/tsdb/collection/gauge.rs
+++ b/metriken-query/src/tsdb/collection/gauge.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Represents a collection of gauge timeseries keyed on label sets.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct GaugeCollection {
     inner: HashMap<Labels, GaugeSeries>,
 }

--- a/metriken-query/src/tsdb/collection/histogram.rs
+++ b/metriken-query/src/tsdb/collection/histogram.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Represents a collection of histogram timeseries keyed on label sets.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct HistogramCollection {
     inner: HashMap<Labels, HistogramSeries>,
 }

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -23,7 +23,7 @@ pub use heatmap::Heatmap;
 pub use labels::Labels;
 pub use series::*;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Tsdb {
     sampling_interval_ms: u64,
     source: String,
@@ -229,6 +229,79 @@ impl Tsdb {
         }
 
         Ok(data)
+    }
+
+    pub fn set_sampling_interval_ms(&mut self, ms: u64) {
+        self.sampling_interval_ms = ms;
+    }
+
+    pub fn set_source(&mut self, source: String) {
+        self.source = source;
+    }
+
+    pub fn set_version(&mut self, version: String) {
+        self.version = version;
+    }
+
+    pub fn set_filename(&mut self, filename: String) {
+        self.filename = filename;
+    }
+
+    /// Ingest a snapshot from a running agent, inserting all metrics into the
+    /// TSDB.
+    pub fn ingest(&mut self, mut snapshot: metriken_exposition::Snapshot) {
+        let ts = snapshot
+            .systemtime()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("system clock is earlier than 1970")
+            .as_nanos() as u64;
+
+        for counter in snapshot.counters() {
+            let (name, labels) = Self::extract_name_labels(&counter.metadata);
+            self.counters
+                .entry(name)
+                .or_default()
+                .entry(labels)
+                .or_default()
+                .insert(ts, counter.value);
+        }
+
+        for gauge in snapshot.gauges() {
+            let (name, labels) = Self::extract_name_labels(&gauge.metadata);
+            self.gauges
+                .entry(name)
+                .or_default()
+                .entry(labels)
+                .or_default()
+                .insert(ts, gauge.value);
+        }
+
+        for histogram in snapshot.histograms() {
+            let (name, labels) = Self::extract_name_labels(&histogram.metadata);
+            self.histograms
+                .entry(name)
+                .or_default()
+                .entry(labels)
+                .or_default()
+                .insert(ts, histogram.value);
+        }
+    }
+
+    /// Extract the metric name and labels from snapshot metric metadata.
+    fn extract_name_labels(metadata: &HashMap<String, String>) -> (String, Labels) {
+        let name = metadata.get("metric").cloned().unwrap_or_default();
+
+        let mut labels = Labels::default();
+        for (k, v) in metadata {
+            match k.as_str() {
+                "metric" | "unit" | "grouping_power" | "max_value_power" => continue,
+                _ => {
+                    labels.inner.insert(k.clone(), v.clone());
+                }
+            }
+        }
+
+        (name, labels)
     }
 
     pub fn counters(&self, name: &str, labels: impl Into<Labels>) -> Option<CounterCollection> {

--- a/metriken-query/src/tsdb/series/histogram.rs
+++ b/metriken-query/src/tsdb/series/histogram.rs
@@ -51,7 +51,13 @@ impl HistogramSeries {
         let mut result = vec![UntypedSeries::default(); percentiles.len()];
 
         for (time, curr) in self.inner.iter().skip(1) {
-            let delta = curr.wrapping_sub(prev).unwrap();
+            let delta = match curr.wrapping_sub(prev) {
+                Ok(d) => d,
+                Err(_) => {
+                    prev = curr;
+                    continue;
+                }
+            };
 
             if let Ok(Some(percentiles)) = delta.percentiles(&pct_100) {
                 for (id, (_, bucket)) in percentiles.iter().enumerate() {
@@ -83,7 +89,13 @@ impl HistogramSeries {
         let mut bucket_bounds_set = false;
 
         for (time, curr) in self.inner.iter().skip(1) {
-            let delta = curr.wrapping_sub(prev).unwrap();
+            let delta = match curr.wrapping_sub(prev) {
+                Ok(d) => d,
+                Err(_) => {
+                    prev = curr;
+                    continue;
+                }
+            };
             let time_index = result.timestamps.len();
 
             // Store timestamp in seconds
@@ -133,7 +145,10 @@ impl Add<&HistogramSeries> for HistogramSeries {
 
         for (time, histogram) in other.inner.iter() {
             if let Some(h) = result.inner.get_mut(time) {
-                *h = h.wrapping_add(histogram).expect("histogram mismatch");
+                if let Ok(sum) = h.wrapping_add(histogram) {
+                    *h = sum;
+                }
+                // Skip mismatched histograms rather than panicking
             } else {
                 result.inner.insert(*time, histogram.clone());
             }


### PR DESCRIPTION
## Summary
- Make `QueryEngine` generic over `Deref<Target = Tsdb>` so callers can use `&Tsdb` or `Arc<Tsdb>` as needed
- Add `Tsdb::ingest()` for live metric ingestion from `metriken-exposition` snapshots, plus setters and `Clone` derives
- Trim heatmap bucket bounds to the active range when filtering by time window
- Handle histogram `wrapping_sub`/`wrapping_add` errors gracefully instead of panicking

## Test plan
- [x] `cargo clippy -p metriken-query` passes
- [x] `cargo test -p metriken-query` — all 10 tests pass
- [x] `cargo fmt -p metriken-query -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)