### PR TITLE
fix(query): use published version for metriken-exposition dependency

### DIFF
--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
-metriken-exposition = { path = "../metriken-exposition", default-features = false }
+metriken-exposition = { version = "0.12.4", path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Add `version = "0.12.4"` specifier to the `metriken-exposition` dependency so `cargo publish` works correctly
- Retains `path` for workspace-local resolution

## Test plan
- [x] `cargo check -p metriken-query` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)