### PR TITLE
change(exposition): improved default snapshotter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 target/
+.claude/settings.local.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.12.4"
+version = "0.13.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -62,15 +62,19 @@ impl Snapshotter {
         let mut histograms: Vec<Histogram> = Vec::new();
 
         // iterate through the metrics and build-up the snapshot
-        for metric in &metriken::metrics() {
+        // Use numeric IDs as column names to avoid collisions and PromQL
+        // parsing issues. The base metric name is stored in the "metric"
+        // metadata key for Tsdb indexing and PromQL querying.
+        for (metric_id, metric) in metriken::metrics().iter().enumerate() {
             if !(self.filter)(metric) {
                 continue;
             }
+            let column_name = format!("{metric_id}");
 
             match metric.value() {
                 Some(Value::Counter(value)) => {
                     let mut counter = Counter {
-                        name: metric.formatted(metriken::Format::Simple),
+                        name: column_name.clone(),
                         value,
                         metadata: HashMap::from_iter(
                             metric
@@ -79,6 +83,10 @@ impl Snapshotter {
                                 .map(|(k, v)| (k.to_string(), v.to_string())),
                         ),
                     };
+
+                    counter
+                        .metadata
+                        .insert("metric".to_string(), metric.name().replace('/', "_"));
 
                     if let Some(description) = metric.description().map(|v| v.to_string()) {
                         counter
@@ -90,7 +98,7 @@ impl Snapshotter {
                 }
                 Some(Value::Gauge(value)) => {
                     let mut gauge = Gauge {
-                        name: metric.formatted(metriken::Format::Simple),
+                        name: column_name.clone(),
                         value,
                         metadata: HashMap::from_iter(
                             metric
@@ -99,6 +107,10 @@ impl Snapshotter {
                                 .map(|(k, v)| (k.to_string(), v.to_string())),
                         ),
                     };
+
+                    gauge
+                        .metadata
+                        .insert("metric".to_string(), metric.name().replace('/', "_"));
 
                     if let Some(description) = metric.description().map(|v| v.to_string()) {
                         gauge
@@ -126,6 +138,8 @@ impl Snapshotter {
                                 .map(|(k, v)| (k.to_string(), v.to_string())),
                         );
 
+                        metadata.insert("metric".to_string(), metric.name().replace('/', "_"));
+
                         // Store configuration parameters as metadata
                         metadata.insert(
                             "grouping_power".to_string(),
@@ -141,7 +155,7 @@ impl Snapshotter {
                         }
 
                         let histogram = Histogram {
-                            name: metric.formatted(metriken::Format::Simple),
+                            name: column_name.clone(),
                             value: histogram,
                             metadata,
                         };

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
-metriken-exposition = { path = "../metriken-exposition", default-features = false }
+metriken-exposition = { version = "0.12.4", path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -13,7 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
-metriken-exposition = { version = "0.12.4", path = "../metriken-exposition", default-features = false }
+metriken-exposition = { version = "0.13.0", path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This change makes the default exposition snapshotter more like what we have in Rezolus. Column names are now unique (but opaque) numeric identifiers and instead we rely on the 'metric' label containing the logical metric name (which is now automatically added).

Also adds automatic addition of description and histogram config metadata. 

As a result, simple tools (such as llm-perf) which have no custom metric types (meaning, they use only the built-in Counter, Gauge, AtomicHistogram) will not need any custom snapshot logic.