### PR TITLE
Use numeric column IDs and inject metric metadata in snapshotter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 target/
 .claude/settings.local.json
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 target/
+.claude/settings.local.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "arrow",
  "chrono",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.12.4"
+version = "0.13.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -10,7 +10,7 @@ use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
 use parquet::format::{FileMetaData, KeyValue};
 
-use crate::snapshot::{canonicalize_metric_name, HashedSnapshot, Snapshot};
+use crate::snapshot::{HashedSnapshot, Snapshot};
 
 /// The batch size (or maximum row group size) is the number of rows that
 /// the `ArrowWriter` caches in memory before attempting to write them to
@@ -168,18 +168,21 @@ impl ParquetSchema {
         );
 
         for counter in counters {
-            let name = canonicalize_metric_name(&counter.name, &counter.metadata);
-            self.counters.entry(name).or_insert(counter.metadata);
+            self.counters
+                .entry(counter.name.clone())
+                .or_insert(counter.metadata);
         }
 
         for gauge in gauges {
-            let name = canonicalize_metric_name(&gauge.name, &gauge.metadata);
-            self.gauges.entry(name).or_insert(gauge.metadata);
+            self.gauges
+                .entry(gauge.name.clone())
+                .or_insert(gauge.metadata);
         }
 
         for histogram in histograms {
-            let name = canonicalize_metric_name(&histogram.name, &histogram.metadata);
-            self.histograms.entry(name).or_insert(histogram.metadata);
+            self.histograms
+                .entry(histogram.name.clone())
+                .or_insert(histogram.metadata);
         }
 
         let snap_metadata = snapshot.metadata();

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -97,8 +97,16 @@ pub(crate) fn canonicalize_metric_name(
     // ignored. We are indifferent to the ordering of keys in neither of these
     // buckets.
     let ordered = ["name", "op", "state", "direction"];
-    let mut ignore: HashSet<&str> =
-        ["metric", "unit", "grouping_power", "max_value_power", "id"].into();
+    let mut ignore: HashSet<&str> = [
+        "metric",
+        "metric_type",
+        "unit",
+        "description",
+        "grouping_power",
+        "max_value_power",
+        "id",
+    ]
+    .into();
     ignore.extend(ordered);
 
     let mut unique_name = name.to_string();
@@ -106,7 +114,7 @@ pub(crate) fn canonicalize_metric_name(
     // Append name, op, state, and direction in specified order
     for k in ordered {
         if let Some(v) = metadata.get(&k) {
-            unique_name = unique_name + "/" + *v;
+            unique_name = unique_name + "_" + *v;
         }
     }
 
@@ -115,12 +123,12 @@ pub(crate) fn canonicalize_metric_name(
         if ignore.contains(*k) {
             continue;
         }
-        unique_name = unique_name + "/" + v;
+        unique_name = unique_name + "_" + v;
     }
 
     // Append "id", if it exists, to the very end
     if let Some(v) = metadata.get("id") {
-        unique_name = unique_name + "/" + v;
+        unique_name = unique_name + "_" + v;
     }
 
     unique_name

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
 #[cfg(feature = "msgpack")]
@@ -76,64 +76,6 @@ pub(crate) struct HashedSnapshot {
     pub(crate) histograms: HashMap<String, Histogram>,
 }
 
-/// Return the metric name: for Rezolus v4 data, this is the metric name
-/// from the snapshot. Rezolus v5 snapshots have metrics with opaque names
-/// with the real name being in the metadata.
-pub(crate) fn canonicalize_metric_name(
-    snapshot_name: &str,
-    metadata: &HashMap<String, String>,
-) -> String {
-    // If the metric key doesn't exist, it is old-style data and return as-is.
-    let Some(name) = metadata.get("metric") else {
-        return snapshot_name.to_string();
-    };
-
-    let metadata: BTreeMap<&str, &str> = metadata
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-
-    // Separate keys into key's with a specific desired ordering and keys to be
-    // ignored. We are indifferent to the ordering of keys in neither of these
-    // buckets.
-    let ordered = ["name", "op", "state", "direction"];
-    let mut ignore: HashSet<&str> = [
-        "metric",
-        "metric_type",
-        "unit",
-        "description",
-        "grouping_power",
-        "max_value_power",
-        "id",
-    ]
-    .into();
-    ignore.extend(ordered);
-
-    let mut unique_name = name.to_string();
-
-    // Append name, op, state, and direction in specified order
-    for k in ordered {
-        if let Some(v) = metadata.get(&k) {
-            unique_name = unique_name + "_" + *v;
-        }
-    }
-
-    // Append remaining keys in any order to ensure uniqueness
-    for (k, v) in &metadata {
-        if ignore.contains(*k) {
-            continue;
-        }
-        unique_name = unique_name + "_" + v;
-    }
-
-    // Append "id", if it exists, to the very end
-    if let Some(v) = metadata.get("id") {
-        unique_name = unique_name + "_" + v;
-    }
-
-    unique_name
-}
-
 impl Snapshot {
     pub fn systemtime(&self) -> SystemTime {
         match self {
@@ -207,23 +149,15 @@ impl From<Snapshot> for HashedSnapshot {
 
         let duration: Option<u64> = snapshot.duration().map(|x| x.as_nanos() as u64);
 
-        let counters: HashMap<String, Counter> = HashMap::from_iter(
-            snapshot
-                .counters()
-                .into_iter()
-                .map(|v| (canonicalize_metric_name(&v.name, &v.metadata), v)),
-        );
-        let gauges: HashMap<String, Gauge> = HashMap::from_iter(
-            snapshot
-                .gauges()
-                .into_iter()
-                .map(|v| (canonicalize_metric_name(&v.name, &v.metadata), v)),
-        );
+        let counters: HashMap<String, Counter> =
+            HashMap::from_iter(snapshot.counters().into_iter().map(|v| (v.name.clone(), v)));
+        let gauges: HashMap<String, Gauge> =
+            HashMap::from_iter(snapshot.gauges().into_iter().map(|v| (v.name.clone(), v)));
         let histograms: HashMap<String, Histogram> = HashMap::from_iter(
             snapshot
                 .histograms()
                 .into_iter()
-                .map(|v| (canonicalize_metric_name(&v.name, &v.metadata), v)),
+                .map(|v| (v.name.clone(), v)),
         );
 
         Self {

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -62,15 +62,19 @@ impl Snapshotter {
         let mut histograms: Vec<Histogram> = Vec::new();
 
         // iterate through the metrics and build-up the snapshot
-        for metric in &metriken::metrics() {
+        // Use numeric IDs as column names to avoid collisions and PromQL
+        // parsing issues. The base metric name is stored in the "metric"
+        // metadata key for Tsdb indexing and PromQL querying.
+        for (metric_id, metric) in metriken::metrics().iter().enumerate() {
             if !(self.filter)(metric) {
                 continue;
             }
+            let column_name = format!("{metric_id}");
 
             match metric.value() {
                 Some(Value::Counter(value)) => {
                     let mut counter = Counter {
-                        name: metric.formatted(metriken::Format::Simple),
+                        name: column_name.clone(),
                         value,
                         metadata: HashMap::from_iter(
                             metric
@@ -79,6 +83,10 @@ impl Snapshotter {
                                 .map(|(k, v)| (k.to_string(), v.to_string())),
                         ),
                     };
+
+                    counter
+                        .metadata
+                        .insert("metric".to_string(), metric.name().replace('/', "_"));
 
                     if let Some(description) = metric.description().map(|v| v.to_string()) {
                         counter
@@ -90,7 +98,7 @@ impl Snapshotter {
                 }
                 Some(Value::Gauge(value)) => {
                     let mut gauge = Gauge {
-                        name: metric.formatted(metriken::Format::Simple),
+                        name: column_name.clone(),
                         value,
                         metadata: HashMap::from_iter(
                             metric
@@ -99,6 +107,10 @@ impl Snapshotter {
                                 .map(|(k, v)| (k.to_string(), v.to_string())),
                         ),
                     };
+
+                    gauge
+                        .metadata
+                        .insert("metric".to_string(), metric.name().replace('/', "_"));
 
                     if let Some(description) = metric.description().map(|v| v.to_string()) {
                         gauge
@@ -126,6 +138,8 @@ impl Snapshotter {
                                 .map(|(k, v)| (k.to_string(), v.to_string())),
                         );
 
+                        metadata.insert("metric".to_string(), metric.name().replace('/', "_"));
+
                         // Store configuration parameters as metadata
                         metadata.insert(
                             "grouping_power".to_string(),
@@ -141,7 +155,7 @@ impl Snapshotter {
                         }
 
                         let histogram = Histogram {
-                            name: metric.formatted(metriken::Format::Simple),
+                            name: column_name.clone(),
                             value: histogram,
                             metadata,
                         };

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
-metriken-exposition = { path = "../metriken-exposition", default-features = false }
+metriken-exposition = { version = "0.12.4", path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -13,7 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
-metriken-exposition = { version = "0.12.4", path = "../metriken-exposition", default-features = false }
+metriken-exposition = { version = "0.13.0", path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Snapshotter now uses numeric IDs (`0`, `1`, `2`, ...) as parquet column names instead of `Format::Simple` names
- Injects `"metric"` metadata key with the base metric name (sanitizing `/` to `_`) for Tsdb/PromQL indexing
- Removes `canonicalize_metric_name` which was overriding column names and leaking descriptions into them
- Bumps metriken-exposition to 0.13.1, metriken-query to 0.4.0

## Motivation
Tools like llm-perf have metrics with the same base name but different metadata labels (e.g., `tokens` with `direction="input"` vs `direction="output"`). The old snapshotter used `Format::Simple` which returned the bare name, causing column collisions. The `canonicalize_metric_name` function attempted to fix this but produced names with embedded descriptions and `/` separators that broke PromQL parsing.

This aligns the `SnapshotterBuilder` with Rezolus's approach: numeric column IDs for uniqueness, `"metric"` metadata for querying.

## Test plan
- [x] `cargo test` passes for metriken-exposition and metriken-query
- [ ] Verify llm-perf produces parquet with numeric column IDs
- [ ] Verify forge Tsdb can query metrics via PromQL label selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)