### PR TITLE
fix(exposition): remove canonicalize_metric_name overriding numeric column IDs

### DIFF
--- a/metriken-exposition/src/parquet.rs
+++ b/metriken-exposition/src/parquet.rs
@@ -10,7 +10,7 @@ use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
 use parquet::format::{FileMetaData, KeyValue};
 
-use crate::snapshot::{canonicalize_metric_name, HashedSnapshot, Snapshot};
+use crate::snapshot::{HashedSnapshot, Snapshot};
 
 /// The batch size (or maximum row group size) is the number of rows that
 /// the `ArrowWriter` caches in memory before attempting to write them to
@@ -168,18 +168,21 @@ impl ParquetSchema {
         );
 
         for counter in counters {
-            let name = canonicalize_metric_name(&counter.name, &counter.metadata);
-            self.counters.entry(name).or_insert(counter.metadata);
+            self.counters
+                .entry(counter.name.clone())
+                .or_insert(counter.metadata);
         }
 
         for gauge in gauges {
-            let name = canonicalize_metric_name(&gauge.name, &gauge.metadata);
-            self.gauges.entry(name).or_insert(gauge.metadata);
+            self.gauges
+                .entry(gauge.name.clone())
+                .or_insert(gauge.metadata);
         }
 
         for histogram in histograms {
-            let name = canonicalize_metric_name(&histogram.name, &histogram.metadata);
-            self.histograms.entry(name).or_insert(histogram.metadata);
+            self.histograms
+                .entry(histogram.name.clone())
+                .or_insert(histogram.metadata);
         }
 
         let snap_metadata = snapshot.metadata();

--- a/metriken-exposition/src/snapshot.rs
+++ b/metriken-exposition/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
 #[cfg(feature = "msgpack")]
@@ -76,56 +76,6 @@ pub(crate) struct HashedSnapshot {
     pub(crate) histograms: HashMap<String, Histogram>,
 }
 
-/// Return the metric name: for Rezolus v4 data, this is the metric name
-/// from the snapshot. Rezolus v5 snapshots have metrics with opaque names
-/// with the real name being in the metadata.
-pub(crate) fn canonicalize_metric_name(
-    snapshot_name: &str,
-    metadata: &HashMap<String, String>,
-) -> String {
-    // If the metric key doesn't exist, it is old-style data and return as-is.
-    let Some(name) = metadata.get("metric") else {
-        return snapshot_name.to_string();
-    };
-
-    let metadata: BTreeMap<&str, &str> = metadata
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-
-    // Separate keys into key's with a specific desired ordering and keys to be
-    // ignored. We are indifferent to the ordering of keys in neither of these
-    // buckets.
-    let ordered = ["name", "op", "state", "direction"];
-    let mut ignore: HashSet<&str> =
-        ["metric", "unit", "grouping_power", "max_value_power", "id"].into();
-    ignore.extend(ordered);
-
-    let mut unique_name = name.to_string();
-
-    // Append name, op, state, and direction in specified order
-    for k in ordered {
-        if let Some(v) = metadata.get(&k) {
-            unique_name = unique_name + "/" + *v;
-        }
-    }
-
-    // Append remaining keys in any order to ensure uniqueness
-    for (k, v) in &metadata {
-        if ignore.contains(*k) {
-            continue;
-        }
-        unique_name = unique_name + "/" + v;
-    }
-
-    // Append "id", if it exists, to the very end
-    if let Some(v) = metadata.get("id") {
-        unique_name = unique_name + "/" + v;
-    }
-
-    unique_name
-}
-
 impl Snapshot {
     pub fn systemtime(&self) -> SystemTime {
         match self {
@@ -199,23 +149,15 @@ impl From<Snapshot> for HashedSnapshot {
 
         let duration: Option<u64> = snapshot.duration().map(|x| x.as_nanos() as u64);
 
-        let counters: HashMap<String, Counter> = HashMap::from_iter(
-            snapshot
-                .counters()
-                .into_iter()
-                .map(|v| (canonicalize_metric_name(&v.name, &v.metadata), v)),
-        );
-        let gauges: HashMap<String, Gauge> = HashMap::from_iter(
-            snapshot
-                .gauges()
-                .into_iter()
-                .map(|v| (canonicalize_metric_name(&v.name, &v.metadata), v)),
-        );
+        let counters: HashMap<String, Counter> =
+            HashMap::from_iter(snapshot.counters().into_iter().map(|v| (v.name.clone(), v)));
+        let gauges: HashMap<String, Gauge> =
+            HashMap::from_iter(snapshot.gauges().into_iter().map(|v| (v.name.clone(), v)));
         let histograms: HashMap<String, Histogram> = HashMap::from_iter(
             snapshot
                 .histograms()
                 .into_iter()
-                .map(|v| (canonicalize_metric_name(&v.name, &v.metadata), v)),
+                .map(|v| (v.name.clone(), v)),
         );
 
         Self {

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -61,64 +61,45 @@ impl Snapshotter {
         let mut gauges: Vec<Gauge> = Vec::new();
         let mut histograms: Vec<Histogram> = Vec::new();
 
-        // iterate through the metrics and build-up the snapshot
-        // Use numeric IDs as column names to avoid collisions and PromQL
-        // parsing issues. The base metric name is stored in the "metric"
-        // metadata key for Tsdb indexing and PromQL querying.
+        // Iterate through metrics using numeric IDs as column names to avoid
+        // collisions between same-name metrics with different labels. The base
+        // metric name is stored in the "metric" metadata key for Tsdb/PromQL
+        // indexing.
         for (metric_id, metric) in metriken::metrics().iter().enumerate() {
             if !(self.filter)(metric) {
                 continue;
             }
             let column_name = format!("{metric_id}");
 
+            // Build metadata from user-defined labels + metric base name
+            let build_metadata = |metric: &MetricEntry| -> HashMap<String, String> {
+                let mut metadata = HashMap::from_iter(
+                    metric
+                        .metadata()
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string())),
+                );
+                metadata.insert("metric".to_string(), metric.name().replace('/', "_"));
+                if let Some(description) = metric.description().map(|v| v.to_string()) {
+                    metadata.insert("description".to_string(), description);
+                }
+                metadata
+            };
+
             match metric.value() {
                 Some(Value::Counter(value)) => {
-                    let mut counter = Counter {
+                    counters.push(Counter {
                         name: column_name.clone(),
                         value,
-                        metadata: HashMap::from_iter(
-                            metric
-                                .metadata()
-                                .into_iter()
-                                .map(|(k, v)| (k.to_string(), v.to_string())),
-                        ),
-                    };
-
-                    counter
-                        .metadata
-                        .insert("metric".to_string(), metric.name().replace('/', "_"));
-
-                    if let Some(description) = metric.description().map(|v| v.to_string()) {
-                        counter
-                            .metadata
-                            .insert("description".to_string(), description);
-                    }
-
-                    counters.push(counter);
+                        metadata: build_metadata(metric),
+                    });
                 }
                 Some(Value::Gauge(value)) => {
-                    let mut gauge = Gauge {
+                    gauges.push(Gauge {
                         name: column_name.clone(),
                         value,
-                        metadata: HashMap::from_iter(
-                            metric
-                                .metadata()
-                                .into_iter()
-                                .map(|(k, v)| (k.to_string(), v.to_string())),
-                        ),
-                    };
-
-                    gauge
-                        .metadata
-                        .insert("metric".to_string(), metric.name().replace('/', "_"));
-
-                    if let Some(description) = metric.description().map(|v| v.to_string()) {
-                        gauge
-                            .metadata
-                            .insert("description".to_string(), description);
-                    }
-
-                    gauges.push(gauge);
+                        metadata: build_metadata(metric),
+                    });
                 }
                 Some(Value::Other(other)) => {
                     let histogram = if let Some(histogram) = other.downcast_ref::<AtomicHistogram>()
@@ -131,16 +112,7 @@ impl Snapshotter {
                     };
 
                     if let Some(histogram) = histogram {
-                        let mut metadata = HashMap::from_iter(
-                            metric
-                                .metadata()
-                                .into_iter()
-                                .map(|(k, v)| (k.to_string(), v.to_string())),
-                        );
-
-                        metadata.insert("metric".to_string(), metric.name().replace('/', "_"));
-
-                        // Store configuration parameters as metadata
+                        let mut metadata = build_metadata(metric);
                         metadata.insert(
                             "grouping_power".to_string(),
                             histogram.config().grouping_power().to_string(),
@@ -150,17 +122,11 @@ impl Snapshotter {
                             histogram.config().max_value_power().to_string(),
                         );
 
-                        if let Some(description) = metric.description().map(|v| v.to_string()) {
-                            metadata.insert("description".to_string(), description);
-                        }
-
-                        let histogram = Histogram {
+                        histograms.push(Histogram {
                             name: column_name.clone(),
                             value: histogram,
                             metadata,
-                        };
-
-                        histograms.push(histogram);
+                        });
                     }
                 }
                 _ => continue,


### PR DESCRIPTION
## Summary
- Remove `canonicalize_metric_name` which was overriding the snapshotter's numeric column IDs with human-readable names that included descriptions and `/` separators (breaking PromQL)
- Parquet columns are now numeric IDs (`0`, `1`, `2`, ...) as set by the snapshotter
- The `"metric"` metadata key (added in #60) carries the base name for Tsdb indexing

## Motivation
`canonicalize_metric_name` was rebuilding column names from metadata, producing names like `tokens/output/Output tokens generated` which are invalid PromQL identifiers. The numeric IDs from the snapshotter are sufficient — the `"metric"` metadata key is what the Tsdb actually uses for lookups.

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)