### PR TITLE
prepare for release metriken-exposition 0.13.1 and metriken-query 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -13,7 +13,7 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow = "56.1.0"
 histogram = "0.11.0"
-metriken-exposition = { version = "0.13.0", path = "../metriken-exposition", default-features = false }
+metriken-exposition = { version = "0.13.1", path = "../metriken-exposition", default-features = false }
 parquet = "56.1.0"
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump `metriken-exposition` from 0.13.0 to 0.13.1
- Bump `metriken-query` from 0.4.0 to 0.4.1
- Update `metriken-query` dependency on `metriken-exposition` to 0.13.1

## Test plan
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)