### PR TITLE
Add optional stride parameter to histogram percentiles and heatmap

### DIFF
--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -90,6 +90,43 @@ pub struct QueryEngine<T: Deref<Target = Tsdb> = Arc<Tsdb>> {
     tsdb: T,
 }
 
+/// Try to parse an optional stride (in seconds) from the trailing argument.
+/// Input like `"metric, 15"` returns `("metric", Some(15_000_000_000))`.
+/// Input like `"metric"` returns `("metric", None)`.
+fn parse_optional_stride(s: &str) -> Result<(&str, Option<u64>), QueryError> {
+    let (before, after) = split_last_top_level_comma(s);
+    if let Some(tail) = after {
+        if let Ok(secs) = tail.parse::<f64>() {
+            if secs <= 0.0 {
+                return Err(QueryError::ParseError(
+                    "stride must be a positive number of seconds".to_string(),
+                ));
+            }
+            return Ok((before.trim(), Some((secs * 1_000_000_000.0) as u64)));
+        }
+    }
+    Ok((s, None))
+}
+
+/// Split a string at the last comma that is not inside `{}` braces.
+/// Returns `(before, Some(after))` if found, or `(whole_string, None)`.
+fn split_last_top_level_comma(s: &str) -> (&str, Option<&str>) {
+    let mut brace_depth = 0i32;
+    let mut last_comma = None;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '{' => brace_depth += 1,
+            '}' => brace_depth -= 1,
+            ',' if brace_depth == 0 => last_comma = Some(i),
+            _ => {}
+        }
+    }
+    match last_comma {
+        Some(i) => (&s[..i], Some(s[i + 1..].trim())),
+        None => (s, None),
+    }
+}
+
 impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
     pub fn new(tsdb: T) -> Self {
         Self { tsdb }
@@ -706,7 +743,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                         let summed_series = collection.sum();
 
                         // Calculate the percentile
-                        if let Some(percentile_series) = summed_series.percentiles(&[quantile]) {
+                        if let Some(percentile_series) = summed_series.percentiles(&[quantile], None) {
                             if let Some(series) = percentile_series.first() {
                                 let start_ns = (start * 1e9) as u64;
                                 let end_ns = (end * 1e9) as u64;
@@ -1435,7 +1472,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
 
         // Extract the metric selector (everything after the array and comma)
         let after_array = &inner[array_end + 1..].trim();
-        let metric_selector = after_array
+        let remaining = after_array
             .strip_prefix(',')
             .map(|s| s.trim())
             .ok_or_else(|| {
@@ -1443,6 +1480,9 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                     "histogram_percentiles requires a metric name as second argument".to_string(),
                 )
             })?;
+
+        // Split off an optional trailing stride parameter (e.g. ", 15")
+        let (metric_selector, stride_ns) = parse_optional_stride(remaining)?;
 
         // Parse the metric selector to extract name and labels
         let (metric_name, labels) = self.parse_metric_selector(metric_selector)?;
@@ -1453,7 +1493,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             let summed_series = collection.sum();
 
             // Calculate all percentiles
-            if let Some(percentile_series_vec) = summed_series.percentiles(&percentiles) {
+            if let Some(percentile_series_vec) = summed_series.percentiles(&percentiles, stride_ns) {
                 let start_ns = (start * 1e9) as u64;
                 let end_ns = (end * 1e9) as u64;
 
@@ -1531,9 +1571,9 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         start: f64,
         end: f64,
     ) -> Result<QueryResult, QueryError> {
-        // Extract the metric selector from histogram_heatmap(metric_selector)
+        // Extract the metric selector from histogram_heatmap(metric_selector[, stride])
         let inner = &query_str["histogram_heatmap(".len()..query_str.len() - 1];
-        let metric_selector = inner.trim();
+        let (metric_selector, stride_ns) = parse_optional_stride(inner.trim())?;
 
         // Parse the metric selector to extract name and labels
         let (metric_name, labels) = self.parse_metric_selector(metric_selector)?;
@@ -1544,7 +1584,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             let summed_series = collection.sum();
 
             // Get heatmap data
-            if let Some(heatmap_data) = summed_series.heatmap() {
+            if let Some(heatmap_data) = summed_series.heatmap(stride_ns) {
                 let start_sec = start;
                 let end_sec = end;
 

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -743,7 +743,9 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                         let summed_series = collection.sum();
 
                         // Calculate the percentile
-                        if let Some(percentile_series) = summed_series.percentiles(&[quantile], None) {
+                        if let Some(percentile_series) =
+                            summed_series.percentiles(&[quantile], None)
+                        {
                             if let Some(series) = percentile_series.first() {
                                 let start_ns = (start * 1e9) as u64;
                                 let end_ns = (end * 1e9) as u64;
@@ -1493,7 +1495,8 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             let summed_series = collection.sum();
 
             // Calculate all percentiles
-            if let Some(percentile_series_vec) = summed_series.percentiles(&percentiles, stride_ns) {
+            if let Some(percentile_series_vec) = summed_series.percentiles(&percentiles, stride_ns)
+            {
                 let start_ns = (start * 1e9) as u64;
                 let end_ns = (end * 1e9) as u64;
 

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -363,7 +363,7 @@ impl Tsdb {
         percentiles: &[f64],
     ) -> Option<Vec<UntypedSeries>> {
         if let Some(collection) = self.histograms(metric, labels) {
-            collection.sum().percentiles(percentiles)
+            collection.sum().percentiles(percentiles, None)
         } else {
             None
         }

--- a/metriken-query/src/tsdb/series/histogram.rs
+++ b/metriken-query/src/tsdb/series/histogram.rs
@@ -37,20 +37,34 @@ impl HistogramSeries {
         Some((min, max))
     }
 
-    pub fn percentiles(&self, percentiles: &[f64]) -> Option<Vec<UntypedSeries>> {
+    pub fn percentiles(
+        &self,
+        percentiles: &[f64],
+        stride_ns: Option<u64>,
+    ) -> Option<Vec<UntypedSeries>> {
         if self.is_empty() {
             return None;
         }
 
-        let (_, mut prev) = self.inner.first_key_value().unwrap();
+        let (&first_time, first_hist) = self.inner.first_key_value().unwrap();
+        let mut prev = first_hist;
+        let mut prev_time = first_time;
 
         let mut result = vec![UntypedSeries::default(); percentiles.len()];
 
         for (time, curr) in self.inner.iter().skip(1) {
+            // With a stride, skip snapshots until we've covered the stride window.
+            if let Some(stride) = stride_ns {
+                if *time - prev_time < stride {
+                    continue;
+                }
+            }
+
             let delta = match curr.wrapping_sub(prev) {
                 Ok(d) => d,
                 Err(_) => {
                     prev = curr;
+                    prev_time = *time;
                     continue;
                 }
             };
@@ -62,6 +76,7 @@ impl HistogramSeries {
             }
 
             prev = curr;
+            prev_time = *time;
         }
 
         Some(result)
@@ -69,7 +84,7 @@ impl HistogramSeries {
 
     /// Returns bucket data suitable for rendering as a heatmap.
     /// Y-axis is bucket index (latency range), X-axis is time, color is count.
-    pub fn heatmap(&self) -> Option<HistogramHeatmapData> {
+    pub fn heatmap(&self, stride_ns: Option<u64>) -> Option<HistogramHeatmapData> {
         if self.inner.len() < 2 {
             return None;
         }
@@ -78,17 +93,27 @@ impl HistogramSeries {
         let mut min_value = f64::MAX;
         let mut max_value = f64::MIN;
 
-        let (_, mut prev) = self.inner.first_key_value().unwrap();
+        let (&first_time, first_hist) = self.inner.first_key_value().unwrap();
+        let mut prev = first_hist;
+        let mut prev_time = first_time;
 
         // Collect bucket boundaries from the first histogram
         // (all histograms in the series should have the same config)
         let mut bucket_bounds_set = false;
 
         for (time, curr) in self.inner.iter().skip(1) {
+            // With a stride, skip snapshots until we've covered the stride window.
+            if let Some(stride) = stride_ns {
+                if *time - prev_time < stride {
+                    continue;
+                }
+            }
+
             let delta = match curr.wrapping_sub(prev) {
                 Ok(d) => d,
                 Err(_) => {
                     prev = curr;
+                    prev_time = *time;
                     continue;
                 }
             };
@@ -117,6 +142,7 @@ impl HistogramSeries {
 
             bucket_bounds_set = true;
             prev = curr;
+            prev_time = *time;
         }
 
         // Handle edge cases


### PR DESCRIPTION
## Summary
This PR adds support for an optional stride parameter to histogram-based query functions, allowing users to control the sampling interval when computing percentiles and heatmaps. This enables more efficient analysis of high-frequency histogram data by skipping intermediate snapshots.

## Key Changes
- **New utility functions** for parsing optional stride parameters:
  - `parse_optional_stride()`: Extracts an optional trailing stride value (in seconds) from query strings
  - `split_last_top_level_comma()`: Safely splits strings at the last comma outside of `{}` braces

- **Updated histogram methods** to accept and use stride parameters:
  - `HistogramSeries::percentiles()` now accepts `stride_ns: Option<u64>` parameter
  - `HistogramSeries::heatmap()` now accepts `stride_ns: Option<u64>` parameter
  - Both methods skip snapshots when stride is specified until the stride window is covered

- **Updated query handlers** to parse and pass stride parameters:
  - `histogram_percentile()` query handler now parses optional stride from input like `"metric, 15"`
  - `histogram_heatmap()` query handler now parses optional stride from input
  - Both pass the parsed stride to their respective histogram methods

## Implementation Details
- Stride values are specified in seconds and converted to nanoseconds internally (multiplied by 1e9)
- Stride validation ensures only positive values are accepted
- The stride parameter is optional and backward compatible—queries without stride continue to work as before
- Stride parsing respects metric label syntax by only splitting at commas outside of `{}` braces
- When stride is applied, the implementation tracks both the previous histogram value and its timestamp to determine when the stride window has been covered

https://claude.ai/code/session_01TiHK4XeAc8t5wBvZvdznPy