### PR TITLE
Respect query step parameter in vector selector evaluation

### DIFF
--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -1328,6 +1328,8 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
 
                     let start_ns = (start * 1e9) as u64;
                     let end_ns = (end * 1e9) as u64;
+                    let step_ns = (step * 1e9) as u64;
+                    let interval_ns = (self.tsdb.interval() * 1e9) as u64;
 
                     let mut result_samples = Vec::new();
 
@@ -1338,11 +1340,29 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                             continue;
                         }
                         let untyped = series.untyped();
-                        let values: Vec<(f64, f64)> = untyped
-                            .inner
-                            .range(start_ns..=end_ns)
-                            .map(|(ts, val)| (*ts as f64 / 1e9, *val))
-                            .collect();
+                        let values: Vec<(f64, f64)> = if step_ns > interval_ns {
+                            // Step is coarser than native interval:
+                            // evaluate at step-aligned timestamps
+                            let mut vals = Vec::new();
+                            let mut current = start_ns;
+                            while current <= end_ns {
+                                if let Some((&ts, &val)) =
+                                    untyped.inner.range(..=current).next_back()
+                                {
+                                    if current - ts <= step_ns {
+                                        vals.push((current as f64 / 1e9, val));
+                                    }
+                                }
+                                current += step_ns;
+                            }
+                            vals
+                        } else {
+                            untyped
+                                .inner
+                                .range(start_ns..=end_ns)
+                                .map(|(ts, val)| (*ts as f64 / 1e9, *val))
+                                .collect()
+                        };
 
                         if !values.is_empty() {
                             let mut metric_labels = HashMap::new();

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -698,3 +698,55 @@ fn test_rate_parse_error_without_range() {
     let result = engine.query_range("rate(test_counter)", 0.0, 3600.0, 60.0);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_vector_selector_respects_coarse_step() {
+    let tsdb = Arc::new(create_gauge_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    // Gauge: t=1000:10, t=1001:20, t=1002:30, t=1003:40, t=1004:50
+    // With step=2.0, should produce 3 points at t=1000, 1002, 1004
+    let result = engine
+        .query_range("test_gauge", 1000.0, 1004.0, 2.0)
+        .unwrap();
+
+    let all_values = get_matrix_values(&result);
+    assert_eq!(all_values.len(), 1);
+    assert_eq!(
+        all_values[0].len(),
+        3,
+        "Expected 3 step-aligned points, got {}",
+        all_values[0].len()
+    );
+
+    // Timestamps should be step-aligned
+    assert!((all_values[0][0].0 - 1000.0).abs() < 1e-6);
+    assert!((all_values[0][1].0 - 1002.0).abs() < 1e-6);
+    assert!((all_values[0][2].0 - 1004.0).abs() < 1e-6);
+
+    // Values at those timestamps
+    assert!((all_values[0][0].1 - 10.0).abs() < 1e-6);
+    assert!((all_values[0][1].1 - 30.0).abs() < 1e-6);
+    assert!((all_values[0][2].1 - 50.0).abs() < 1e-6);
+}
+
+#[test]
+fn test_vector_selector_preserves_all_points_when_step_equals_interval() {
+    let tsdb = Arc::new(create_gauge_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    // Gauge: t=1000:10, t=1001:20, t=1002:30, t=1003:40, t=1004:50
+    // With step=1.0 (same as native interval), should return all 5 points
+    let result = engine
+        .query_range("test_gauge", 1000.0, 1004.0, 1.0)
+        .unwrap();
+
+    let all_values = get_matrix_values(&result);
+    assert_eq!(all_values.len(), 1);
+    assert_eq!(
+        all_values[0].len(),
+        5,
+        "Expected all 5 raw points, got {}",
+        all_values[0].len()
+    );
+}

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -750,3 +750,77 @@ fn test_vector_selector_preserves_all_points_when_step_equals_interval() {
         all_values[0].len()
     );
 }
+
+/// Create a TSDB with two gauge metrics for binary expression testing.
+/// "mem_total" = 1000 at every timestamp, "mem_available" = 800, 700, 600, 500, 400
+/// at t=1000..1004.
+fn create_two_gauge_tsdb() -> Tsdb {
+    use metriken_exposition::{Gauge, Snapshot, SnapshotV2};
+
+    let mut tsdb = Tsdb::default();
+    let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+
+    for step in 0u64..5 {
+        let time = base_time + Duration::from_secs(step);
+        let mut meta_total = HashMap::new();
+        meta_total.insert("metric".to_string(), "mem_total".to_string());
+        let mut meta_avail = HashMap::new();
+        meta_avail.insert("metric".to_string(), "mem_available".to_string());
+
+        let snapshot = Snapshot::V2(SnapshotV2 {
+            systemtime: time,
+            duration: Duration::from_secs(1),
+            metadata: HashMap::new(),
+            counters: Vec::new(),
+            gauges: vec![
+                Gauge {
+                    name: "mem_total".to_string(),
+                    value: 1000,
+                    metadata: meta_total,
+                },
+                Gauge {
+                    name: "mem_available".to_string(),
+                    value: 800 - (step as i64 * 100),
+                    metadata: meta_avail,
+                },
+            ],
+            histograms: Vec::new(),
+        });
+        tsdb.ingest(snapshot);
+    }
+
+    tsdb
+}
+
+#[test]
+fn test_compound_gauge_expression_respects_step() {
+    let tsdb = Arc::new(create_two_gauge_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    // mem_total = 1000 at all timestamps
+    // mem_available: t=1000:800, t=1001:700, t=1002:600, t=1003:500, t=1004:400
+    // mem_total - mem_available: 200, 300, 400, 500, 600
+    // With step=2.0, should get 3 points at t=1000, 1002, 1004
+    let result = engine
+        .query_range("mem_total - mem_available", 1000.0, 1004.0, 2.0)
+        .unwrap();
+
+    let all_values = get_matrix_values(&result);
+    assert_eq!(all_values.len(), 1, "should have 1 result series");
+    assert_eq!(
+        all_values[0].len(),
+        3,
+        "Expected 3 step-aligned points, got {}",
+        all_values[0].len()
+    );
+
+    // Verify timestamps and values
+    assert!((all_values[0][0].0 - 1000.0).abs() < 1e-6);
+    assert!((all_values[0][0].1 - 200.0).abs() < 1e-6); // 1000 - 800
+
+    assert!((all_values[0][1].0 - 1002.0).abs() < 1e-6);
+    assert!((all_values[0][1].1 - 400.0).abs() < 1e-6); // 1000 - 600
+
+    assert!((all_values[0][2].0 - 1004.0).abs() < 1e-6);
+    assert!((all_values[0][2].1 - 600.0).abs() < 1e-6); // 1000 - 400
+}

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -751,10 +751,11 @@ fn test_vector_selector_preserves_all_points_when_step_equals_interval() {
     );
 }
 
-/// Create a TSDB with two gauge metrics for binary expression testing.
-/// "mem_total" = 1000 at every timestamp, "mem_available" = 800, 700, 600, 500, 400
-/// at t=1000..1004.
-fn create_two_gauge_tsdb() -> Tsdb {
+/// Create a TSDB with three gauge metrics for binary expression testing.
+/// "mem_total" = 1000 at every timestamp
+/// "mem_available" = 800, 700, 600, 500, 400 at t=1000..1004
+/// "mem_reserved" = 50 at every timestamp
+fn create_three_gauge_tsdb() -> Tsdb {
     use metriken_exposition::{Gauge, Snapshot, SnapshotV2};
 
     let mut tsdb = Tsdb::default();
@@ -766,6 +767,8 @@ fn create_two_gauge_tsdb() -> Tsdb {
         meta_total.insert("metric".to_string(), "mem_total".to_string());
         let mut meta_avail = HashMap::new();
         meta_avail.insert("metric".to_string(), "mem_available".to_string());
+        let mut meta_reserved = HashMap::new();
+        meta_reserved.insert("metric".to_string(), "mem_reserved".to_string());
 
         let snapshot = Snapshot::V2(SnapshotV2 {
             systemtime: time,
@@ -783,6 +786,11 @@ fn create_two_gauge_tsdb() -> Tsdb {
                     value: 800 - (step as i64 * 100),
                     metadata: meta_avail,
                 },
+                Gauge {
+                    name: "mem_reserved".to_string(),
+                    value: 50,
+                    metadata: meta_reserved,
+                },
             ],
             histograms: Vec::new(),
         });
@@ -794,7 +802,7 @@ fn create_two_gauge_tsdb() -> Tsdb {
 
 #[test]
 fn test_compound_gauge_expression_respects_step() {
-    let tsdb = Arc::new(create_two_gauge_tsdb());
+    let tsdb = Arc::new(create_three_gauge_tsdb());
     let engine = QueryEngine::new(tsdb);
 
     // mem_total = 1000 at all timestamps
@@ -823,4 +831,45 @@ fn test_compound_gauge_expression_respects_step() {
 
     assert!((all_values[0][2].0 - 1004.0).abs() < 1e-6);
     assert!((all_values[0][2].1 - 600.0).abs() < 1e-6); // 1000 - 400
+}
+
+#[test]
+fn test_triple_gauge_expression_respects_step() {
+    let tsdb = Arc::new(create_three_gauge_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    // mem_total = 1000, mem_available = {800,700,600,500,400}, mem_reserved = 50
+    // (mem_total - mem_available) - mem_reserved => (a - b) - c
+    //   t=1000: (1000 - 800) - 50 = 150
+    //   t=1001: (1000 - 700) - 50 = 250
+    //   t=1002: (1000 - 600) - 50 = 350
+    //   t=1003: (1000 - 500) - 50 = 450
+    //   t=1004: (1000 - 400) - 50 = 550
+    // With step=2.0, expect 3 points at t=1000, 1002, 1004
+    let result = engine
+        .query_range(
+            "mem_total - mem_available - mem_reserved",
+            1000.0,
+            1004.0,
+            2.0,
+        )
+        .unwrap();
+
+    let all_values = get_matrix_values(&result);
+    assert_eq!(all_values.len(), 1, "should have 1 result series");
+    assert_eq!(
+        all_values[0].len(),
+        3,
+        "Expected 3 step-aligned points, got {}",
+        all_values[0].len()
+    );
+
+    assert!((all_values[0][0].0 - 1000.0).abs() < 1e-6);
+    assert!((all_values[0][0].1 - 150.0).abs() < 1e-6); // (1000-800)-50
+
+    assert!((all_values[0][1].0 - 1002.0).abs() < 1e-6);
+    assert!((all_values[0][1].1 - 350.0).abs() < 1e-6); // (1000-600)-50
+
+    assert!((all_values[0][2].0 - 1004.0).abs() < 1e-6);
+    assert!((all_values[0][2].1 - 550.0).abs() < 1e-6); // (1000-400)-50
 }


### PR DESCRIPTION
## Summary
This PR fixes vector selector evaluation to respect the query step parameter when it is coarser than the native data interval. Previously, vector selectors would always return all raw data points regardless of the requested step size, causing inconsistent behavior compared to other query operations.

## Key Changes
- **Vector selector step alignment**: Modified `QueryEngine::query_range()` to evaluate vector selectors at step-aligned timestamps when `step > interval`. For coarser steps, the engine now samples the nearest preceding value at each step boundary rather than returning all raw points.
- **Conditional evaluation logic**: Added branching logic that:
  - When step is coarser than the native interval: evaluates at step-aligned timestamps using `range(..=current).next_back()` to find the most recent value
  - When step equals or is finer than the native interval: returns all raw data points as before
- **Comprehensive test coverage**: Added three new tests:
  - `test_vector_selector_respects_coarse_step`: Verifies step-aligned output with step=2.0
  - `test_vector_selector_preserves_all_points_when_step_equals_interval`: Ensures no data loss when step matches native interval
  - `test_compound_gauge_expression_respects_step`: Validates that binary expressions also respect step alignment

## Implementation Details
- The fix converts step and interval to nanoseconds for consistent comparison and iteration
- Uses BTreeMap's `range(..=current).next_back()` to efficiently find the most recent data point at or before each step-aligned timestamp
- Only applies step-aligned sampling when `step_ns > interval_ns`, preserving backward compatibility for fine-grained queries
- Includes a helper function `create_two_gauge_tsdb()` for testing binary expressions with multiple metrics

https://claude.ai/code/session_01AStVmmf5AaHaU9LnD3aMMa