### PR TITLE
Add group metric types, sharded counters, and Prometheus renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
 name = "metriken-core"
 version = "0.1.3"
 dependencies = [
+ "histogram",
  "linkme",
  "parking_lot",
  "phf",

--- a/metriken-core/Cargo.toml
+++ b/metriken-core/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 links = "metriken-core"
 
 [dependencies]
+histogram = "1.0.0"
 linkme = "0.3"
 parking_lot = "0.12"
 phf = { version = "0.11", features = ["macros"] }

--- a/metriken-core/src/lib.rs
+++ b/metriken-core/src/lib.rs
@@ -30,12 +30,16 @@ mod metadata;
 mod metrics;
 mod null;
 mod provide;
+mod traits;
 mod wrapper;
 
 pub use crate::formatter::{default_formatter, Format};
 pub use crate::metadata::{Metadata, MetadataIter};
 pub use crate::metrics::{metrics, DynMetricsIter, Metrics, MetricsIter};
 pub use crate::provide::{request_ref, request_value, Request};
+pub use crate::traits::{
+    CounterGroupMetric, GaugeGroupMetric, HistogramGroupMetric, HistogramMetric,
+};
 
 /// Global interface to a metric.
 ///
@@ -87,6 +91,18 @@ pub enum Value<'a> {
 
     /// A gauge value.
     Gauge(i64),
+
+    /// A histogram metric that can produce snapshots.
+    Histogram(&'a dyn HistogramMetric),
+
+    /// A group of counter metrics with per-entry metadata.
+    CounterGroup(&'a dyn CounterGroupMetric),
+
+    /// A group of gauge metrics with per-entry metadata.
+    GaugeGroup(&'a dyn GaugeGroupMetric),
+
+    /// A group of histogram metrics with per-entry metadata.
+    HistogramGroup(&'a dyn HistogramGroupMetric),
 
     /// The value of the metric could not be represented using the other `Value`
     /// variants.

--- a/metriken-core/src/traits.rs
+++ b/metriken-core/src/traits.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+/// Trait for histogram metrics that can produce snapshots.
+///
+/// Implemented by both `AtomicHistogram` (for recording individual events)
+/// and `RwLockHistogram` (for bulk updates from pre-aggregated data).
+/// Exposition code can use this trait without knowing which variant it has.
+pub trait HistogramMetric: Send + Sync + 'static {
+    /// Return the histogram configuration.
+    fn config(&self) -> histogram::Config;
+
+    /// Load a snapshot of the histogram.
+    ///
+    /// Returns `None` if the histogram has never been written to.
+    fn load(&self) -> Option<histogram::Histogram>;
+}
+
+/// Trait for a group of counter metrics with per-entry metadata.
+///
+/// Counter groups store a dense array of `u64` values indexed by `usize`,
+/// with sparse metadata attached to individual entries.
+pub trait CounterGroupMetric: Send + Sync + 'static {
+    /// Return the number of entries in this group.
+    fn entries(&self) -> usize;
+
+    /// Load the value of the counter at `idx`.
+    fn counter_value(&self, idx: usize) -> Option<u64>;
+
+    /// Load all counter values as a snapshot.
+    fn load_counters(&self) -> Option<Vec<u64>>;
+
+    /// Load metadata for the entry at `idx`.
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>>;
+
+    /// Snapshot all metadata.
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)>;
+}
+
+/// Trait for a group of gauge metrics with per-entry metadata.
+///
+/// Gauge groups store a dense array of `i64` values indexed by `usize`,
+/// with sparse metadata attached to individual entries.
+pub trait GaugeGroupMetric: Send + Sync + 'static {
+    /// Return the number of entries in this group.
+    fn entries(&self) -> usize;
+
+    /// Load the value of the gauge at `idx`.
+    fn gauge_value(&self, idx: usize) -> Option<i64>;
+
+    /// Load all gauge values as a snapshot.
+    fn load_gauges(&self) -> Option<Vec<i64>>;
+
+    /// Load metadata for the entry at `idx`.
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>>;
+
+    /// Snapshot all metadata.
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)>;
+}
+
+/// Trait for a group of histogram metrics with per-entry metadata.
+///
+/// Histogram groups store a dense array of histograms (all sharing the same
+/// configuration) indexed by `usize`, with sparse metadata attached to
+/// individual entries.
+pub trait HistogramGroupMetric: Send + Sync + 'static {
+    /// Return the number of entries in this group.
+    fn entries(&self) -> usize;
+
+    /// Return the histogram configuration shared by all entries.
+    fn config(&self) -> histogram::Config;
+
+    /// Load a snapshot of the histogram at `idx`.
+    fn load_histogram(&self, idx: usize) -> Option<histogram::Histogram>;
+
+    /// Load snapshots of all histograms.
+    fn load_all_histograms(&self) -> Option<Vec<histogram::Histogram>>;
+
+    /// Load metadata for the entry at `idx`.
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>>;
+
+    /// Snapshot all metadata.
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)>;
+}

--- a/metriken-exposition/src/lib.rs
+++ b/metriken-exposition/src/lib.rs
@@ -7,6 +7,7 @@
 mod convert;
 #[cfg(feature = "parquet")]
 mod parquet;
+mod prometheus;
 mod snapshot;
 mod snapshotter;
 
@@ -16,5 +17,6 @@ pub use convert::MsgpackToParquet;
 pub use parquet::{
     ParquetCompression, ParquetHistogramType, ParquetOptions, ParquetSchema, ParquetWriter,
 };
+pub use prometheus::{prometheus_text, PrometheusOptions};
 pub use snapshot::{Counter, Gauge, Histogram, Snapshot, SnapshotV1, SnapshotV2};
 pub use snapshotter::{Snapshotter, SnapshotterBuilder};

--- a/metriken-exposition/src/prometheus.rs
+++ b/metriken-exposition/src/prometheus.rs
@@ -1,0 +1,313 @@
+use std::collections::HashMap;
+use std::fmt::Write;
+
+use metriken::{MetricEntry, Value};
+
+/// Options for Prometheus text format rendering.
+pub struct PrometheusOptions {
+    /// Include `# HELP` lines when metric descriptions are available.
+    pub help_text: bool,
+    /// Percentiles to compute for histogram summaries (0.0-1.0 scale).
+    /// If empty, full cumulative bucket exposition is used instead.
+    pub percentiles: Vec<f64>,
+}
+
+impl Default for PrometheusOptions {
+    fn default() -> Self {
+        Self {
+            help_text: true,
+            percentiles: Vec::new(),
+        }
+    }
+}
+
+impl PrometheusOptions {
+    /// Use summary-style histogram exposition with these percentiles.
+    pub fn with_percentiles(mut self, percentiles: Vec<f64>) -> Self {
+        self.percentiles = percentiles;
+        self
+    }
+
+    /// Disable `# HELP` lines.
+    pub fn without_help(mut self) -> Self {
+        self.help_text = false;
+        self
+    }
+}
+
+/// Render all registered metriken metrics in Prometheus text exposition format.
+///
+/// This walks the global metric registry and produces a complete Prometheus
+/// response body. Group metrics are exploded into individual labeled series.
+///
+/// # Example
+/// ```no_run
+/// use metriken_exposition::prometheus_text;
+/// use metriken_exposition::PrometheusOptions;
+///
+/// let body = prometheus_text(&PrometheusOptions::default());
+/// ```
+pub fn prometheus_text(options: &PrometheusOptions) -> String {
+    let mut output = String::new();
+
+    for metric in &metriken::metrics() {
+        let name = sanitize_name(metric.name());
+
+        match metric.value() {
+            Some(Value::Counter(value)) => {
+                write_type_help(&mut output, &name, "counter", metric, options);
+                write_metric_line(&mut output, &name, None, &value.to_string());
+            }
+            Some(Value::Gauge(value)) => {
+                write_type_help(&mut output, &name, "gauge", metric, options);
+                write_metric_line(&mut output, &name, None, &value.to_string());
+            }
+            Some(Value::Histogram(h)) => {
+                if let Some(snapshot) = h.load() {
+                    write_histogram(&mut output, &name, None, &snapshot, metric, options);
+                }
+            }
+            Some(Value::CounterGroup(g)) => {
+                let base_metadata = entry_metadata(metric);
+                if let Some(values) = g.load_counters() {
+                    let mut first = true;
+                    for (idx, &value) in values.iter().enumerate() {
+                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
+                        if first {
+                            write_type_help(&mut output, &name, "counter", metric, options);
+                            first = false;
+                        }
+                        write_metric_line(&mut output, &name, Some(&labels), &value.to_string());
+                    }
+                }
+            }
+            Some(Value::GaugeGroup(g)) => {
+                let base_metadata = entry_metadata(metric);
+                if let Some(values) = g.load_gauges() {
+                    let mut first = true;
+                    for (idx, &value) in values.iter().enumerate() {
+                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
+                        if first {
+                            write_type_help(&mut output, &name, "gauge", metric, options);
+                            first = false;
+                        }
+                        write_metric_line(&mut output, &name, Some(&labels), &value.to_string());
+                    }
+                }
+            }
+            Some(Value::HistogramGroup(g)) => {
+                let base_metadata = entry_metadata(metric);
+                if let Some(hists) = g.load_all_histograms() {
+                    for (idx, snapshot) in hists.iter().enumerate() {
+                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
+                        write_histogram(
+                            &mut output,
+                            &name,
+                            Some(&labels),
+                            snapshot,
+                            metric,
+                            options,
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    output
+}
+
+fn write_type_help(
+    output: &mut String,
+    name: &str,
+    kind: &str,
+    metric: &MetricEntry,
+    options: &PrometheusOptions,
+) {
+    if options.help_text {
+        if let Some(description) = metric.description() {
+            let _ = writeln!(output, "# HELP {name} {description}");
+        }
+    }
+    let _ = writeln!(output, "# TYPE {name} {kind}");
+}
+
+fn write_metric_line(output: &mut String, name: &str, labels: Option<&str>, value: &str) {
+    match labels {
+        Some(l) if !l.is_empty() => {
+            let _ = writeln!(output, "{name}{{{l}}} {value}");
+        }
+        _ => {
+            let _ = writeln!(output, "{name} {value}");
+        }
+    }
+}
+
+fn write_histogram(
+    output: &mut String,
+    name: &str,
+    labels: Option<&str>,
+    snapshot: &histogram::Histogram,
+    metric: &MetricEntry,
+    options: &PrometheusOptions,
+) {
+    if !options.percentiles.is_empty() {
+        // Summary-style: emit percentile gauges
+        write_type_help(output, name, "summary", metric, options);
+
+        if let Ok(Some(results)) = snapshot.percentiles(&options.percentiles) {
+            for (percentile, bucket) in results {
+                let value = bucket.end();
+                let quantile_label = format!("quantile=\"{percentile}\"");
+                let combined = match labels {
+                    Some(l) if !l.is_empty() => format!("{l}, {quantile_label}"),
+                    _ => quantile_label,
+                };
+                write_metric_line(output, name, Some(&combined), &value.to_string());
+            }
+        }
+
+        // count and sum
+        let mut count: u64 = 0;
+        let mut sum: u128 = 0;
+        for bucket in snapshot {
+            let c = bucket.count();
+            count += c;
+            sum += c as u128 * ((bucket.start() as u128 + bucket.end() as u128) / 2);
+        }
+        write_metric_line(output, &format!("{name}_count"), labels, &count.to_string());
+        write_metric_line(output, &format!("{name}_sum"), labels, &sum.to_string());
+    } else {
+        // Full cumulative bucket exposition
+        write_type_help(output, name, "histogram", metric, options);
+
+        let mut count: u64 = 0;
+        let mut sum: u128 = 0;
+        for bucket in snapshot {
+            let c = bucket.count();
+            sum += c as u128 * bucket.end() as u128;
+            count += c;
+            let le_label = format!("le=\"{}\"", bucket.end());
+            let combined = match labels {
+                Some(l) if !l.is_empty() => format!("{l}, {le_label}"),
+                _ => le_label,
+            };
+            write_metric_line(
+                output,
+                &format!("{name}_bucket"),
+                Some(&combined),
+                &count.to_string(),
+            );
+        }
+        let inf_label = "le=\"+Inf\"".to_string();
+        let combined = match labels {
+            Some(l) if !l.is_empty() => format!("{l}, {inf_label}"),
+            _ => inf_label,
+        };
+        write_metric_line(
+            output,
+            &format!("{name}_bucket"),
+            Some(&combined),
+            &count.to_string(),
+        );
+        write_metric_line(output, &format!("{name}_count"), labels, &count.to_string());
+        write_metric_line(output, &format!("{name}_sum"), labels, &sum.to_string());
+    }
+}
+
+/// Extract metadata key-value pairs from a metric entry.
+fn entry_metadata(metric: &MetricEntry) -> HashMap<String, String> {
+    metric
+        .metadata()
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+/// Merge base metadata from the metric entry with per-index group metadata,
+/// and format as a Prometheus label string.
+fn merge_labels(
+    base: &HashMap<String, String>,
+    index_meta: Option<HashMap<String, String>>,
+) -> String {
+    let mut all = base.clone();
+    if let Some(meta) = index_meta {
+        all.extend(meta);
+    }
+    format_labels(&all)
+}
+
+/// Format a metadata map as a sorted Prometheus label string.
+fn format_labels(metadata: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<String> = metadata
+        .iter()
+        .map(|(k, v)| format!("{k}=\"{v}\""))
+        .collect();
+    pairs.sort();
+    pairs.join(", ")
+}
+
+/// Sanitize a metric name for Prometheus compatibility.
+///
+/// Prometheus metric names must match `[a-zA-Z_:][a-zA-Z0-9_:]*`.
+fn sanitize_name(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' || c == ':' {
+            result.push(c);
+        } else {
+            result.push('_');
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_name() {
+        assert_eq!(sanitize_name("simple"), "simple");
+        assert_eq!(sanitize_name("with/slash"), "with_slash");
+        assert_eq!(sanitize_name("with.dots"), "with_dots");
+        assert_eq!(sanitize_name("ok_under_score"), "ok_under_score");
+        assert_eq!(sanitize_name("has:colon"), "has:colon");
+    }
+
+    #[test]
+    fn test_format_labels() {
+        let mut meta = HashMap::new();
+        meta.insert("b".into(), "2".into());
+        meta.insert("a".into(), "1".into());
+        assert_eq!(format_labels(&meta), "a=\"1\", b=\"2\"");
+    }
+
+    #[test]
+    fn test_format_labels_empty() {
+        let meta = HashMap::new();
+        assert_eq!(format_labels(&meta), "");
+    }
+
+    #[test]
+    fn test_write_metric_line_no_labels() {
+        let mut out = String::new();
+        write_metric_line(&mut out, "my_counter", None, "42");
+        assert_eq!(out, "my_counter 42\n");
+    }
+
+    #[test]
+    fn test_write_metric_line_with_labels() {
+        let mut out = String::new();
+        write_metric_line(&mut out, "my_counter", Some("cpu=\"0\""), "42");
+        assert_eq!(out, "my_counter{cpu=\"0\"} 42\n");
+    }
+
+    #[test]
+    fn test_write_metric_line_empty_labels() {
+        let mut out = String::new();
+        write_metric_line(&mut out, "my_counter", Some(""), "42");
+        assert_eq!(out, "my_counter 42\n");
+    }
+}

--- a/metriken-exposition/src/prometheus.rs
+++ b/metriken-exposition/src/prometheus.rs
@@ -69,42 +69,51 @@ pub fn prometheus_text(options: &PrometheusOptions) -> String {
             }
             Some(Value::CounterGroup(g)) => {
                 let base_metadata = entry_metadata(metric);
-                if let Some(values) = g.load_counters() {
-                    let mut first = true;
-                    for (idx, &value) in values.iter().enumerate() {
-                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
-                        if first {
-                            write_type_help(&mut output, &name, "counter", metric, options);
-                            first = false;
+                let active = g.metadata_snapshot();
+                if !active.is_empty() {
+                    write_type_help(&mut output, &name, "counter", metric, options);
+                    for (idx, entry_meta) in active {
+                        if let Some(value) = g.counter_value(idx) {
+                            let labels = merge_labels(&base_metadata, Some(entry_meta));
+                            write_metric_line(
+                                &mut output,
+                                &name,
+                                Some(&labels),
+                                &value.to_string(),
+                            );
                         }
-                        write_metric_line(&mut output, &name, Some(&labels), &value.to_string());
                     }
                 }
             }
             Some(Value::GaugeGroup(g)) => {
                 let base_metadata = entry_metadata(metric);
-                if let Some(values) = g.load_gauges() {
-                    let mut first = true;
-                    for (idx, &value) in values.iter().enumerate() {
-                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
-                        if first {
-                            write_type_help(&mut output, &name, "gauge", metric, options);
-                            first = false;
+                let active = g.metadata_snapshot();
+                if !active.is_empty() {
+                    write_type_help(&mut output, &name, "gauge", metric, options);
+                    for (idx, entry_meta) in active {
+                        if let Some(value) = g.gauge_value(idx) {
+                            let labels = merge_labels(&base_metadata, Some(entry_meta));
+                            write_metric_line(
+                                &mut output,
+                                &name,
+                                Some(&labels),
+                                &value.to_string(),
+                            );
                         }
-                        write_metric_line(&mut output, &name, Some(&labels), &value.to_string());
                     }
                 }
             }
             Some(Value::HistogramGroup(g)) => {
                 let base_metadata = entry_metadata(metric);
-                if let Some(hists) = g.load_all_histograms() {
-                    for (idx, snapshot) in hists.iter().enumerate() {
-                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
+                let active = g.metadata_snapshot();
+                for (idx, entry_meta) in active {
+                    if let Some(snapshot) = g.load_histogram(idx) {
+                        let labels = merge_labels(&base_metadata, Some(entry_meta));
                         write_histogram(
                             &mut output,
                             &name,
                             Some(&labels),
-                            snapshot,
+                            &snapshot,
                             metric,
                             options,
                         );

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::time::SystemTime;
 
-use metriken::{AtomicHistogram, MetricEntry, RwLockHistogram, Value};
+use metriken::{MetricEntry, Value};
 
 use crate::snapshot::{Counter, Gauge, Histogram, Snapshot, SnapshotV1};
 
@@ -101,17 +101,8 @@ impl Snapshotter {
                         metadata: build_metadata(metric),
                     });
                 }
-                Some(Value::Other(other)) => {
-                    let histogram = if let Some(histogram) = other.downcast_ref::<AtomicHistogram>()
-                    {
-                        histogram.load()
-                    } else if let Some(histogram) = other.downcast_ref::<RwLockHistogram>() {
-                        histogram.load()
-                    } else {
-                        None
-                    };
-
-                    if let Some(histogram) = histogram {
+                Some(Value::Histogram(h)) => {
+                    if let Some(histogram) = h.load() {
                         let mut metadata = build_metadata(metric);
                         metadata.insert(
                             "grouping_power".to_string(),
@@ -127,6 +118,62 @@ impl Snapshotter {
                             value: histogram,
                             metadata,
                         });
+                    }
+                }
+                Some(Value::CounterGroup(g)) => {
+                    let base_metadata = build_metadata(metric);
+                    if let Some(values) = g.load_counters() {
+                        for (idx, &value) in values.iter().enumerate() {
+                            let mut metadata = base_metadata.clone();
+                            if let Some(entry_meta) = g.load_metadata(idx) {
+                                metadata.extend(entry_meta);
+                            }
+                            counters.push(Counter {
+                                name: format!("{column_name}x{idx}"),
+                                value,
+                                metadata,
+                            });
+                        }
+                    }
+                }
+                Some(Value::GaugeGroup(g)) => {
+                    let base_metadata = build_metadata(metric);
+                    if let Some(values) = g.load_gauges() {
+                        for (idx, &value) in values.iter().enumerate() {
+                            let mut metadata = base_metadata.clone();
+                            if let Some(entry_meta) = g.load_metadata(idx) {
+                                metadata.extend(entry_meta);
+                            }
+                            gauges.push(Gauge {
+                                name: format!("{column_name}x{idx}"),
+                                value,
+                                metadata,
+                            });
+                        }
+                    }
+                }
+                Some(Value::HistogramGroup(g)) => {
+                    let base_metadata = build_metadata(metric);
+                    if let Some(hists) = g.load_all_histograms() {
+                        for (idx, histogram) in hists.into_iter().enumerate() {
+                            let mut metadata = base_metadata.clone();
+                            if let Some(entry_meta) = g.load_metadata(idx) {
+                                metadata.extend(entry_meta);
+                            }
+                            metadata.insert(
+                                "grouping_power".to_string(),
+                                histogram.config().grouping_power().to_string(),
+                            );
+                            metadata.insert(
+                                "max_value_power".to_string(),
+                                histogram.config().max_value_power().to_string(),
+                            );
+                            histograms.push(Histogram {
+                                name: format!("{column_name}x{idx}"),
+                                value: histogram,
+                                metadata,
+                            });
+                        }
                     }
                 }
                 _ => continue,

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -122,12 +122,10 @@ impl Snapshotter {
                 }
                 Some(Value::CounterGroup(g)) => {
                     let base_metadata = build_metadata(metric);
-                    if let Some(values) = g.load_counters() {
-                        for (idx, &value) in values.iter().enumerate() {
+                    for (idx, entry_meta) in g.metadata_snapshot() {
+                        if let Some(value) = g.counter_value(idx) {
                             let mut metadata = base_metadata.clone();
-                            if let Some(entry_meta) = g.load_metadata(idx) {
-                                metadata.extend(entry_meta);
-                            }
+                            metadata.extend(entry_meta);
                             counters.push(Counter {
                                 name: format!("{column_name}x{idx}"),
                                 value,
@@ -138,12 +136,10 @@ impl Snapshotter {
                 }
                 Some(Value::GaugeGroup(g)) => {
                     let base_metadata = build_metadata(metric);
-                    if let Some(values) = g.load_gauges() {
-                        for (idx, &value) in values.iter().enumerate() {
+                    for (idx, entry_meta) in g.metadata_snapshot() {
+                        if let Some(value) = g.gauge_value(idx) {
                             let mut metadata = base_metadata.clone();
-                            if let Some(entry_meta) = g.load_metadata(idx) {
-                                metadata.extend(entry_meta);
-                            }
+                            metadata.extend(entry_meta);
                             gauges.push(Gauge {
                                 name: format!("{column_name}x{idx}"),
                                 value,
@@ -154,12 +150,10 @@ impl Snapshotter {
                 }
                 Some(Value::HistogramGroup(g)) => {
                     let base_metadata = build_metadata(metric);
-                    if let Some(hists) = g.load_all_histograms() {
-                        for (idx, histogram) in hists.into_iter().enumerate() {
+                    for (idx, entry_meta) in g.metadata_snapshot() {
+                        if let Some(histogram) = g.load_histogram(idx) {
                             let mut metadata = base_metadata.clone();
-                            if let Some(entry_meta) = g.load_metadata(idx) {
-                                metadata.extend(entry_meta);
-                            }
+                            metadata.extend(entry_meta);
                             metadata.insert(
                                 "grouping_power".to_string(),
                                 histogram.config().grouping_power().to_string(),

--- a/metriken/src/group/counter.rs
+++ b/metriken/src/group/counter.rs
@@ -1,0 +1,243 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+
+use super::metadata::GroupMetadata;
+use crate::{CounterGroupMetric, Metric, Value};
+
+/// A group of counters backed by a dense array with sparse metadata.
+///
+/// The value array is allocated lazily on first access and is always dense
+/// (every index from 0..entries has a slot). Metadata is stored sparsely —
+/// only indices with explicitly attached metadata consume memory for it.
+///
+/// This is the right choice for per-CPU, per-cgroup, or per-operation
+/// counters where the index is meaningful (e.g., CPU ID, cgroup index,
+/// enum variant).
+///
+/// # Example
+/// ```
+/// use metriken::{metric, CounterGroup};
+///
+/// const NUM_OPS: usize = 4;
+///
+/// #[metric(name = "requests")]
+/// static REQUESTS: CounterGroup = CounterGroup::new(NUM_OPS);
+///
+/// // Index 0 = reads, 1 = writes, etc.
+/// REQUESTS.increment(0);
+/// REQUESTS.add(1, 5);
+///
+/// assert_eq!(REQUESTS.value(0), Some(1));
+/// assert_eq!(REQUESTS.value(1), Some(5));
+/// ```
+pub struct CounterGroup {
+    values: OnceLock<RwLock<Vec<AtomicU64>>>,
+    metadata: GroupMetadata,
+    entries: usize,
+}
+
+impl CounterGroup {
+    /// Create a new counter group with the given number of entries.
+    pub const fn new(entries: usize) -> Self {
+        Self {
+            values: OnceLock::new(),
+            metadata: GroupMetadata::new(),
+            entries,
+        }
+    }
+
+    /// Return the number of entries in this group.
+    pub fn entries(&self) -> usize {
+        self.entries
+    }
+
+    fn get_or_init(&self) -> &RwLock<Vec<AtomicU64>> {
+        self.values.get_or_init(|| {
+            let mut v = Vec::with_capacity(self.entries);
+            for _ in 0..self.entries {
+                v.push(AtomicU64::new(0));
+            }
+            RwLock::new(v)
+        })
+    }
+
+    /// Increment the counter at `idx` by 1.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn increment(&self, idx: usize) -> bool {
+        self.add(idx, 1)
+    }
+
+    /// Add `value` to the counter at `idx`.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn add(&self, idx: usize, value: u64) -> bool {
+        if idx >= self.entries {
+            return false;
+        }
+        let inner = self.get_or_init().read();
+        inner[idx].fetch_add(value, Ordering::Relaxed);
+        true
+    }
+
+    /// Set the counter at `idx` to `value`.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    pub fn set(&self, idx: usize, value: u64) -> bool {
+        if idx >= self.entries {
+            return false;
+        }
+        let inner = self.get_or_init().read();
+        inner[idx].store(value, Ordering::Relaxed);
+        true
+    }
+
+    /// Load the current value of the counter at `idx`.
+    ///
+    /// Returns `None` if `idx` is out of bounds or values haven't been
+    /// initialized.
+    pub fn value(&self, idx: usize) -> Option<u64> {
+        if idx >= self.entries {
+            return None;
+        }
+        self.values
+            .get()
+            .map(|v| v.read()[idx].load(Ordering::Relaxed))
+    }
+
+    /// Load all counter values as a snapshot.
+    ///
+    /// Returns `None` if the group hasn't been initialized yet.
+    pub fn load(&self) -> Option<Vec<u64>> {
+        self.values
+            .get()
+            .map(|v| v.read().iter().map(|a| a.load(Ordering::Relaxed)).collect())
+    }
+
+    /// Set metadata for the entry at `idx`.
+    pub fn set_metadata(&self, idx: usize, metadata: HashMap<String, String>) {
+        if idx < self.entries {
+            self.metadata.insert(idx, metadata);
+        }
+    }
+
+    /// Set a single metadata key-value pair for the entry at `idx`.
+    pub fn insert_metadata(&self, idx: usize, key: String, value: String) {
+        if idx < self.entries {
+            self.metadata.insert_kv(idx, key, value);
+        }
+    }
+
+    /// Load metadata for the entry at `idx`.
+    pub fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    /// Remove metadata for the entry at `idx`.
+    pub fn clear_metadata(&self, idx: usize) {
+        self.metadata.remove(idx);
+    }
+
+    /// Snapshot all metadata.
+    pub fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
+    }
+}
+
+impl CounterGroupMetric for CounterGroup {
+    fn entries(&self) -> usize {
+        self.entries
+    }
+
+    fn counter_value(&self, idx: usize) -> Option<u64> {
+        self.value(idx)
+    }
+
+    fn load_counters(&self) -> Option<Vec<u64>> {
+        self.load()
+    }
+
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
+    }
+}
+
+impl Metric for CounterGroup {
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn value(&self) -> Option<Value<'_>> {
+        Some(Value::CounterGroup(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_operations() {
+        static GROUP: CounterGroup = CounterGroup::new(4);
+
+        assert_eq!(GROUP.value(0), None); // not yet initialized
+        GROUP.increment(0);
+        assert_eq!(GROUP.value(0), Some(1));
+        GROUP.add(1, 10);
+        assert_eq!(GROUP.value(1), Some(10));
+
+        // out of bounds
+        assert!(!GROUP.increment(4));
+        assert_eq!(GROUP.value(4), None);
+    }
+
+    #[test]
+    fn metadata() {
+        static GROUP: CounterGroup = CounterGroup::new(4);
+
+        GROUP.insert_metadata(0, "cpu".into(), "0".into());
+        GROUP.insert_metadata(0, "node".into(), "numa0".into());
+
+        let meta = GROUP.load_metadata(0).unwrap();
+        assert_eq!(meta.get("cpu").unwrap(), "0");
+        assert_eq!(meta.get("node").unwrap(), "numa0");
+
+        // index without metadata
+        assert!(GROUP.load_metadata(1).is_none());
+
+        GROUP.clear_metadata(0);
+        assert!(GROUP.load_metadata(0).is_none());
+    }
+
+    #[test]
+    fn load_snapshot() {
+        static GROUP: CounterGroup = CounterGroup::new(3);
+
+        GROUP.set(0, 10);
+        GROUP.set(1, 20);
+        GROUP.set(2, 30);
+
+        let snap = GROUP.load().unwrap();
+        assert_eq!(snap, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn metriken_trait() {
+        use crate::Metric;
+
+        static GROUP: CounterGroup = CounterGroup::new(2);
+        GROUP.increment(0);
+
+        let value = Metric::value(&GROUP);
+        assert!(matches!(value, Some(Value::CounterGroup(_))));
+    }
+}

--- a/metriken/src/group/gauge.rs
+++ b/metriken/src/group/gauge.rs
@@ -1,0 +1,244 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+
+use super::metadata::GroupMetadata;
+use crate::{GaugeGroupMetric, Metric, Value};
+
+/// A group of gauges backed by a dense array with sparse metadata.
+///
+/// The value array is allocated lazily on first access and is always dense.
+/// Metadata is stored sparsely.
+///
+/// # Example
+/// ```
+/// use metriken::{metric, GaugeGroup};
+///
+/// const NUM_CPUS: usize = 8;
+///
+/// #[metric(name = "cpu_frequency")]
+/// static CPU_FREQ: GaugeGroup = GaugeGroup::new(NUM_CPUS);
+///
+/// CPU_FREQ.set(0, 3600);
+/// CPU_FREQ.set(1, 2400);
+///
+/// assert_eq!(CPU_FREQ.value(0), Some(3600));
+/// ```
+pub struct GaugeGroup {
+    values: OnceLock<RwLock<Vec<AtomicI64>>>,
+    metadata: GroupMetadata,
+    entries: usize,
+}
+
+impl GaugeGroup {
+    /// Create a new gauge group with the given number of entries.
+    pub const fn new(entries: usize) -> Self {
+        Self {
+            values: OnceLock::new(),
+            metadata: GroupMetadata::new(),
+            entries,
+        }
+    }
+
+    /// Return the number of entries in this group.
+    pub fn entries(&self) -> usize {
+        self.entries
+    }
+
+    fn get_or_init(&self) -> &RwLock<Vec<AtomicI64>> {
+        self.values.get_or_init(|| {
+            let mut v = Vec::with_capacity(self.entries);
+            for _ in 0..self.entries {
+                v.push(AtomicI64::new(0));
+            }
+            RwLock::new(v)
+        })
+    }
+
+    /// Increment the gauge at `idx` by 1.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn increment(&self, idx: usize) -> bool {
+        self.add(idx, 1)
+    }
+
+    /// Decrement the gauge at `idx` by 1.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn decrement(&self, idx: usize) -> bool {
+        self.sub(idx, 1)
+    }
+
+    /// Add `value` to the gauge at `idx`.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn add(&self, idx: usize, value: i64) -> bool {
+        if idx >= self.entries {
+            return false;
+        }
+        let inner = self.get_or_init().read();
+        inner[idx].fetch_add(value, Ordering::Relaxed);
+        true
+    }
+
+    /// Subtract `value` from the gauge at `idx`.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn sub(&self, idx: usize, value: i64) -> bool {
+        if idx >= self.entries {
+            return false;
+        }
+        let inner = self.get_or_init().read();
+        inner[idx].fetch_sub(value, Ordering::Relaxed);
+        true
+    }
+
+    /// Set the gauge at `idx` to `value`.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    pub fn set(&self, idx: usize, value: i64) -> bool {
+        if idx >= self.entries {
+            return false;
+        }
+        let inner = self.get_or_init().read();
+        inner[idx].store(value, Ordering::Relaxed);
+        true
+    }
+
+    /// Load the current value of the gauge at `idx`.
+    ///
+    /// Returns `None` if `idx` is out of bounds or values haven't been
+    /// initialized.
+    pub fn value(&self, idx: usize) -> Option<i64> {
+        if idx >= self.entries {
+            return None;
+        }
+        self.values
+            .get()
+            .map(|v| v.read()[idx].load(Ordering::Relaxed))
+    }
+
+    /// Load all gauge values as a snapshot.
+    ///
+    /// Returns `None` if the group hasn't been initialized yet.
+    pub fn load(&self) -> Option<Vec<i64>> {
+        self.values
+            .get()
+            .map(|v| v.read().iter().map(|a| a.load(Ordering::Relaxed)).collect())
+    }
+
+    /// Set metadata for the entry at `idx`.
+    pub fn set_metadata(&self, idx: usize, metadata: HashMap<String, String>) {
+        if idx < self.entries {
+            self.metadata.insert(idx, metadata);
+        }
+    }
+
+    /// Set a single metadata key-value pair for the entry at `idx`.
+    pub fn insert_metadata(&self, idx: usize, key: String, value: String) {
+        if idx < self.entries {
+            self.metadata.insert_kv(idx, key, value);
+        }
+    }
+
+    /// Load metadata for the entry at `idx`.
+    pub fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    /// Remove metadata for the entry at `idx`.
+    pub fn clear_metadata(&self, idx: usize) {
+        self.metadata.remove(idx);
+    }
+
+    /// Snapshot all metadata.
+    pub fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
+    }
+}
+
+impl GaugeGroupMetric for GaugeGroup {
+    fn entries(&self) -> usize {
+        self.entries
+    }
+
+    fn gauge_value(&self, idx: usize) -> Option<i64> {
+        self.value(idx)
+    }
+
+    fn load_gauges(&self) -> Option<Vec<i64>> {
+        self.load()
+    }
+
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
+    }
+}
+
+impl Metric for GaugeGroup {
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn value(&self) -> Option<Value<'_>> {
+        Some(Value::GaugeGroup(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_operations() {
+        static GROUP: GaugeGroup = GaugeGroup::new(4);
+
+        assert_eq!(GROUP.value(0), None);
+        GROUP.set(0, 100);
+        assert_eq!(GROUP.value(0), Some(100));
+        GROUP.increment(0);
+        assert_eq!(GROUP.value(0), Some(101));
+        GROUP.decrement(0);
+        assert_eq!(GROUP.value(0), Some(100));
+        GROUP.add(1, 50);
+        GROUP.sub(1, 10);
+        assert_eq!(GROUP.value(1), Some(40));
+
+        // out of bounds
+        assert!(!GROUP.set(4, 0));
+        assert_eq!(GROUP.value(4), None);
+    }
+
+    #[test]
+    fn metadata() {
+        static GROUP: GaugeGroup = GaugeGroup::new(4);
+
+        GROUP.insert_metadata(0, "cpu".into(), "0".into());
+        let meta = GROUP.load_metadata(0).unwrap();
+        assert_eq!(meta.get("cpu").unwrap(), "0");
+
+        assert!(GROUP.load_metadata(1).is_none());
+    }
+
+    #[test]
+    fn load_snapshot() {
+        static GROUP: GaugeGroup = GaugeGroup::new(3);
+
+        GROUP.set(0, 10);
+        GROUP.set(1, -20);
+        GROUP.set(2, 30);
+
+        let snap = GROUP.load().unwrap();
+        assert_eq!(snap, vec![10, -20, 30]);
+    }
+}

--- a/metriken/src/group/histogram.rs
+++ b/metriken/src/group/histogram.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use histogram::{Config, Error, Histogram};
+use parking_lot::RwLock;
+
+use super::metadata::GroupMetadata;
+use crate::{HistogramGroupMetric, Metric, Value};
+
+/// A group of histograms backed by a dense array with sparse metadata.
+///
+/// All histograms in the group share the same configuration (grouping power
+/// and max value power). The array is allocated lazily on first access.
+///
+/// # Example
+/// ```
+/// use metriken::{metric, HistogramGroup};
+///
+/// #[metric(name = "latency")]
+/// static LATENCY: HistogramGroup = HistogramGroup::new(4, 7, 64);
+///
+/// // Index 0 = reads, 1 = writes, etc.
+/// let _ = LATENCY.increment(0, 1200);
+/// let _ = LATENCY.increment(1, 500);
+/// ```
+pub struct HistogramGroup {
+    inner: OnceLock<RwLock<Vec<histogram::AtomicHistogram>>>,
+    metadata: GroupMetadata,
+    config: Config,
+    entries: usize,
+}
+
+impl HistogramGroup {
+    /// Create a new histogram group.
+    ///
+    /// All histograms share the same `grouping_power` and `max_value_power`
+    /// configuration.
+    ///
+    /// # Panics
+    /// Panics if the histogram configuration is invalid. See
+    /// [`histogram::Config::new`] for constraints.
+    pub const fn new(entries: usize, grouping_power: u8, max_value_power: u8) -> Self {
+        let config = match Config::new(grouping_power, max_value_power) {
+            Ok(c) => c,
+            Err(_) => panic!("invalid histogram config"),
+        };
+
+        Self {
+            inner: OnceLock::new(),
+            metadata: GroupMetadata::new(),
+            config,
+            entries,
+        }
+    }
+
+    /// Return the number of entries in this group.
+    pub fn entries(&self) -> usize {
+        self.entries
+    }
+
+    /// Return the histogram configuration shared by all entries.
+    pub fn config(&self) -> Config {
+        self.config
+    }
+
+    fn get_or_init(&self) -> &RwLock<Vec<histogram::AtomicHistogram>> {
+        self.inner.get_or_init(|| {
+            let mut v = Vec::with_capacity(self.entries);
+            for _ in 0..self.entries {
+                v.push(histogram::AtomicHistogram::with_config(&self.config));
+            }
+            RwLock::new(v)
+        })
+    }
+
+    /// Record a value in the histogram at `idx`.
+    ///
+    /// Returns `Err` if the value is outside the histogram's range.
+    /// Returns `Ok(false)` if `idx` is out of bounds.
+    pub fn increment(&self, idx: usize, value: u64) -> Result<bool, Error> {
+        if idx >= self.entries {
+            return Ok(false);
+        }
+        let inner = self.get_or_init().read();
+        inner[idx].increment(value)?;
+        Ok(true)
+    }
+
+    /// Load a snapshot of the histogram at `idx`.
+    ///
+    /// Returns `None` if `idx` is out of bounds or the group hasn't been
+    /// initialized.
+    pub fn load(&self, idx: usize) -> Option<Histogram> {
+        if idx >= self.entries {
+            return None;
+        }
+        self.inner.get().map(|v| v.read()[idx].load())
+    }
+
+    /// Load snapshots of all histograms.
+    ///
+    /// Returns `None` if the group hasn't been initialized.
+    pub fn load_all(&self) -> Option<Vec<Histogram>> {
+        self.inner
+            .get()
+            .map(|v| v.read().iter().map(|h| h.load()).collect())
+    }
+
+    /// Set metadata for the entry at `idx`.
+    pub fn set_metadata(&self, idx: usize, metadata: HashMap<String, String>) {
+        if idx < self.entries {
+            self.metadata.insert(idx, metadata);
+        }
+    }
+
+    /// Set a single metadata key-value pair for the entry at `idx`.
+    pub fn insert_metadata(&self, idx: usize, key: String, value: String) {
+        if idx < self.entries {
+            self.metadata.insert_kv(idx, key, value);
+        }
+    }
+
+    /// Load metadata for the entry at `idx`.
+    pub fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    /// Remove metadata for the entry at `idx`.
+    pub fn clear_metadata(&self, idx: usize) {
+        self.metadata.remove(idx);
+    }
+
+    /// Snapshot all metadata.
+    pub fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
+    }
+}
+
+impl HistogramGroupMetric for HistogramGroup {
+    fn entries(&self) -> usize {
+        self.entries
+    }
+
+    fn config(&self) -> Config {
+        self.config
+    }
+
+    fn load_histogram(&self, idx: usize) -> Option<Histogram> {
+        self.load(idx)
+    }
+
+    fn load_all_histograms(&self) -> Option<Vec<Histogram>> {
+        self.load_all()
+    }
+
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
+    }
+}
+
+impl Metric for HistogramGroup {
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn value(&self) -> Option<Value<'_>> {
+        Some(Value::HistogramGroup(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_operations() {
+        static GROUP: HistogramGroup = HistogramGroup::new(4, 7, 64);
+
+        assert!(GROUP.load(0).is_none()); // not initialized yet
+        assert!(GROUP.increment(0, 100).unwrap());
+        assert!(GROUP.load(0).is_some());
+
+        // out of bounds
+        assert!(!GROUP.increment(4, 100).unwrap());
+        assert!(GROUP.load(4).is_none());
+    }
+
+    #[test]
+    fn load_all() {
+        static GROUP: HistogramGroup = HistogramGroup::new(2, 7, 64);
+
+        let _ = GROUP.increment(0, 100);
+        let _ = GROUP.increment(1, 200);
+
+        let all = GROUP.load_all().unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn metadata() {
+        static GROUP: HistogramGroup = HistogramGroup::new(4, 7, 64);
+
+        GROUP.insert_metadata(0, "op".into(), "read".into());
+        let meta = GROUP.load_metadata(0).unwrap();
+        assert_eq!(meta.get("op").unwrap(), "read");
+
+        assert!(GROUP.load_metadata(1).is_none());
+    }
+
+    #[test]
+    fn config() {
+        static GROUP: HistogramGroup = HistogramGroup::new(2, 7, 64);
+        let config = GROUP.config();
+        assert_eq!(config, Config::new(7, 64).unwrap());
+    }
+}

--- a/metriken/src/group/metadata.rs
+++ b/metriken/src/group/metadata.rs
@@ -1,0 +1,61 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// Sparse metadata storage for group metrics.
+///
+/// Only allocates metadata for indices that have been explicitly set.
+/// Suitable for both small dense groups (per-CPU) and large sparse groups
+/// (per-cgroup, per-task) since the overhead for small N is negligible.
+pub(crate) struct GroupMetadata {
+    inner: OnceLock<RwLock<HashMap<usize, HashMap<String, String>>>>,
+}
+
+impl GroupMetadata {
+    pub(crate) const fn new() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    fn get_or_init(&self) -> &RwLock<HashMap<usize, HashMap<String, String>>> {
+        self.inner.get_or_init(|| RwLock::new(HashMap::new()))
+    }
+
+    /// Set metadata for a given index. Replaces any existing metadata.
+    pub(crate) fn insert(&self, idx: usize, metadata: HashMap<String, String>) {
+        self.get_or_init().write().insert(idx, metadata);
+    }
+
+    /// Set a single key-value pair for a given index.
+    pub(crate) fn insert_kv(&self, idx: usize, key: String, value: String) {
+        self.get_or_init()
+            .write()
+            .entry(idx)
+            .or_default()
+            .insert(key, value);
+    }
+
+    /// Load metadata for a given index.
+    pub(crate) fn load(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.inner.get().and_then(|m| m.read().get(&idx).cloned())
+    }
+
+    /// Remove metadata for a given index.
+    pub(crate) fn remove(&self, idx: usize) {
+        if let Some(m) = self.inner.get() {
+            m.write().remove(&idx);
+        }
+    }
+
+    /// Iterate over all (index, metadata) pairs.
+    ///
+    /// Takes a snapshot of the metadata to avoid holding the lock during
+    /// iteration.
+    pub(crate) fn snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        match self.inner.get() {
+            Some(m) => m.read().iter().map(|(k, v)| (*k, v.clone())).collect(),
+            None => Vec::new(),
+        }
+    }
+}

--- a/metriken/src/group/mod.rs
+++ b/metriken/src/group/mod.rs
@@ -1,0 +1,8 @@
+mod counter;
+mod gauge;
+mod histogram;
+mod metadata;
+
+pub use counter::CounterGroup;
+pub use gauge::GaugeGroup;
+pub use histogram::HistogramGroup;

--- a/metriken/src/group/mod.rs
+++ b/metriken/src/group/mod.rs
@@ -1,7 +1,7 @@
 mod counter;
 mod gauge;
 mod histogram;
-mod metadata;
+pub(crate) mod metadata;
 
 pub use counter::CounterGroup;
 pub use gauge::GaugeGroup;

--- a/metriken/src/histogram.rs
+++ b/metriken/src/histogram.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 pub use histogram::{Bucket, Config, Error, Histogram};
 use parking_lot::RwLock;
 
-use crate::{Metric, Value};
+use crate::{HistogramMetric, Metric, Value};
 
 /// A histogram that uses free-running atomic counters to track the distribution
 /// of values. They are only useful for recording values and producing
@@ -60,13 +60,23 @@ impl AtomicHistogram {
     }
 }
 
+impl HistogramMetric for AtomicHistogram {
+    fn config(&self) -> Config {
+        self.config
+    }
+
+    fn load(&self) -> Option<Histogram> {
+        self.load()
+    }
+}
+
 impl Metric for AtomicHistogram {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
 
     fn value(&self) -> Option<Value<'_>> {
-        Some(Value::Other(self))
+        Some(Value::Histogram(self))
     }
 }
 
@@ -134,12 +144,22 @@ impl RwLockHistogram {
     }
 }
 
+impl HistogramMetric for RwLockHistogram {
+    fn config(&self) -> Config {
+        self.config
+    }
+
+    fn load(&self) -> Option<Histogram> {
+        self.load()
+    }
+}
+
 impl Metric for RwLockHistogram {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
 
     fn value(&self) -> Option<Value<'_>> {
-        Some(Value::Other(self))
+        Some(Value::Histogram(self))
     }
 }

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -71,14 +71,17 @@
 
 mod counter;
 mod gauge;
+pub mod group;
 pub mod histogram;
 mod lazy;
+mod sharded;
 
 extern crate self as metriken;
 
 #[doc(inline)]
 pub use metriken_core::{
-    default_formatter, dynmetrics, metrics, DynMetricsIter, Format, Metadata, MetadataIter, Metric,
+    default_formatter, dynmetrics, metrics, CounterGroupMetric, DynMetricsIter, Format,
+    GaugeGroupMetric, HistogramGroupMetric, HistogramMetric, Metadata, MetadataIter, Metric,
     MetricEntry, Metrics, MetricsIter, Value,
 };
 pub use metriken_derive::metric;
@@ -87,8 +90,10 @@ pub use crate::counter::Counter;
 #[doc(inline)]
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric, MetricBuilder};
 pub use crate::gauge::Gauge;
+pub use crate::group::{CounterGroup, GaugeGroup, HistogramGroup};
 pub use crate::histogram::{AtomicHistogram, RwLockHistogram};
 pub use crate::lazy::Lazy;
+pub use crate::sharded::{set_thread_shard, ShardedCounter};
 
 /// A counter holds a unsigned 64bit monotonically non-decreasing value. The
 /// counter behavior is to wrap on overflow.

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -93,7 +93,7 @@ pub use crate::gauge::Gauge;
 pub use crate::group::{CounterGroup, GaugeGroup, HistogramGroup};
 pub use crate::histogram::{AtomicHistogram, RwLockHistogram};
 pub use crate::lazy::Lazy;
-pub use crate::sharded::{set_thread_shard, ShardedCounter};
+pub use crate::sharded::{set_thread_shard, ShardedCounterGroup};
 
 /// A counter holds a unsigned 64bit monotonically non-decreasing value. The
 /// counter behavior is to wrap on overflow.

--- a/metriken/src/sharded.rs
+++ b/metriken/src/sharded.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-const CACHE_LINE: usize = 128;
+const CACHE_LINE: usize = 64;
 const NUM_SHARDS: usize = 64;
 
 thread_local! {
@@ -30,7 +30,7 @@ fn shard_index() -> usize {
     })
 }
 
-#[repr(C, align(128))]
+#[repr(C, align(64))]
 struct Shard {
     value: AtomicU64,
     _pad: [u8; CACHE_LINE - 8],

--- a/metriken/src/sharded.rs
+++ b/metriken/src/sharded.rs
@@ -1,0 +1,168 @@
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const CACHE_LINE: usize = 128;
+const NUM_SHARDS: usize = 64;
+
+thread_local! {
+    static SHARD_ID: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+/// Set the shard ID for the current thread.
+///
+/// Call this at the start of each worker thread to ensure deterministic
+/// shard assignment and avoid false sharing between workers.
+pub fn set_thread_shard(id: usize) {
+    SHARD_ID.set(Some(id % NUM_SHARDS));
+}
+
+/// Get the shard index for the current thread.
+///
+/// Uses the explicitly set shard ID if available (via [`set_thread_shard`]),
+/// otherwise falls back to a hash of a thread-local address.
+#[inline]
+fn shard_index() -> usize {
+    SHARD_ID.get().unwrap_or_else(|| {
+        thread_local! {
+            static ID: u8 = const { 0 };
+        }
+        ID.with(|x| x as *const u8 as usize) % NUM_SHARDS
+    })
+}
+
+#[repr(C, align(128))]
+struct Shard {
+    value: AtomicU64,
+    _pad: [u8; CACHE_LINE - 8],
+}
+
+/// A sharded counter for high-throughput workloads.
+///
+/// Each thread writes to its own cache-line-aligned shard, avoiding
+/// contention. Reading sums across all shards.
+///
+/// Use [`set_thread_shard`] at thread startup for deterministic shard
+/// assignment. Without it, a hash of a thread-local address is used.
+///
+/// # Example
+/// ```
+/// use metriken::{metric, ShardedCounter};
+///
+/// #[metric(name = "requests")]
+/// static REQUESTS: ShardedCounter = ShardedCounter::new();
+///
+/// REQUESTS.increment();
+/// assert!(REQUESTS.value() >= 1);
+/// ```
+pub struct ShardedCounter {
+    shards: [Shard; NUM_SHARDS],
+}
+
+unsafe impl Send for ShardedCounter {}
+unsafe impl Sync for ShardedCounter {}
+
+impl ShardedCounter {
+    /// Create a new sharded counter initialized to zero.
+    #[allow(clippy::declare_interior_mutable_const)]
+    pub const fn new() -> Self {
+        const ZERO: Shard = Shard {
+            value: AtomicU64::new(0),
+            _pad: [0; CACHE_LINE - 8],
+        };
+        Self {
+            shards: [ZERO; NUM_SHARDS],
+        }
+    }
+
+    /// Increment the counter by 1.
+    #[inline]
+    pub fn increment(&self) {
+        self.add(1);
+    }
+
+    /// Add a value to the counter.
+    #[inline]
+    pub fn add(&self, value: u64) {
+        let shard = shard_index();
+        self.shards[shard].value.fetch_add(value, Ordering::Relaxed);
+    }
+
+    /// Get the current value (aggregated across all shards).
+    pub fn value(&self) -> u64 {
+        self.shards
+            .iter()
+            .map(|s| s.value.load(Ordering::Relaxed))
+            .sum()
+    }
+}
+
+impl Default for ShardedCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl crate::Metric for ShardedCounter {
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn value(&self) -> Option<crate::Value<'_>> {
+        Some(crate::Value::Counter(self.value()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        static COUNTER: ShardedCounter = ShardedCounter::new();
+        assert_eq!(COUNTER.value(), 0);
+        COUNTER.increment();
+        assert_eq!(COUNTER.value(), 1);
+        COUNTER.add(10);
+        assert_eq!(COUNTER.value(), 11);
+    }
+
+    #[test]
+    fn thread_distribution() {
+        use std::sync::Arc;
+        use std::thread;
+
+        static COUNTER: ShardedCounter = ShardedCounter::new();
+        let counter = Arc::new(&COUNTER);
+        let iterations: u64 = 1000;
+        let num_threads: u64 = 4;
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|i| {
+                let c = Arc::clone(&counter);
+                thread::spawn(move || {
+                    set_thread_shard(i as usize);
+                    for _ in 0..iterations {
+                        c.increment();
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(COUNTER.value(), iterations * num_threads);
+    }
+
+    #[test]
+    fn metriken_trait() {
+        use crate::Metric;
+
+        static COUNTER: ShardedCounter = ShardedCounter::new();
+        COUNTER.add(42);
+
+        let value = Metric::value(&COUNTER);
+        assert!(matches!(value, Some(crate::Value::Counter(v)) if v >= 42));
+    }
+}

--- a/metriken/src/sharded.rs
+++ b/metriken/src/sharded.rs
@@ -1,7 +1,13 @@
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use crate::group::metadata::GroupMetadata;
+use crate::{CounterGroupMetric, Metric, Value};
 
 const CACHE_LINE: usize = 64;
+const SLOTS_PER_LINE: usize = CACHE_LINE / 8;
 const NUM_SHARDS: usize = 64;
 
 thread_local! {
@@ -16,10 +22,6 @@ pub fn set_thread_shard(id: usize) {
     SHARD_ID.set(Some(id % NUM_SHARDS));
 }
 
-/// Get the shard index for the current thread.
-///
-/// Uses the explicitly set shard ID if available (via [`set_thread_shard`]),
-/// otherwise falls back to a hash of a thread-local address.
 #[inline]
 fn shard_index() -> usize {
     SHARD_ID.get().unwrap_or_else(|| {
@@ -31,84 +33,200 @@ fn shard_index() -> usize {
 }
 
 #[repr(C, align(64))]
-struct Shard {
-    value: AtomicU64,
-    _pad: [u8; CACHE_LINE - 8],
+struct CacheLine {
+    slots: [AtomicU64; SLOTS_PER_LINE],
 }
 
-/// A sharded counter for high-throughput workloads.
+/// A group of sharded counters for high-throughput workloads.
 ///
 /// Each thread writes to its own cache-line-aligned shard, avoiding
-/// contention. Reading sums across all shards.
+/// contention. Related counters are packed into the same cache line(s)
+/// within a shard for spatial locality. Reading sums a given slot across
+/// all shards.
 ///
 /// Use [`set_thread_shard`] at thread startup for deterministic shard
 /// assignment. Without it, a hash of a thread-local address is used.
 ///
 /// # Example
 /// ```
-/// use metriken::{metric, ShardedCounter};
+/// use metriken::{metric, ShardedCounterGroup};
 ///
 /// #[metric(name = "requests")]
-/// static REQUESTS: ShardedCounter = ShardedCounter::new();
+/// static REQUESTS: ShardedCounterGroup = ShardedCounterGroup::new(3);
 ///
-/// REQUESTS.increment();
-/// assert!(REQUESTS.value() >= 1);
+/// // 0 = reads, 1 = writes, 2 = deletes
+/// REQUESTS.increment(0);
+/// REQUESTS.add(1, 5);
+///
+/// assert_eq!(REQUESTS.value(0), Some(1));
+/// assert_eq!(REQUESTS.value(1), Some(5));
 /// ```
-pub struct ShardedCounter {
-    shards: [Shard; NUM_SHARDS],
+pub struct ShardedCounterGroup {
+    values: OnceLock<Vec<CacheLine>>,
+    metadata: GroupMetadata,
+    entries: usize,
+    lines_per_shard: usize,
 }
 
-unsafe impl Send for ShardedCounter {}
-unsafe impl Sync for ShardedCounter {}
+unsafe impl Send for ShardedCounterGroup {}
+unsafe impl Sync for ShardedCounterGroup {}
 
-impl ShardedCounter {
-    /// Create a new sharded counter initialized to zero.
-    #[allow(clippy::declare_interior_mutable_const)]
-    pub const fn new() -> Self {
-        const ZERO: Shard = Shard {
-            value: AtomicU64::new(0),
-            _pad: [0; CACHE_LINE - 8],
-        };
+impl ShardedCounterGroup {
+    /// Create a new sharded counter group with the given number of entries.
+    pub const fn new(entries: usize) -> Self {
+        let lines_per_shard = entries.div_ceil(SLOTS_PER_LINE);
         Self {
-            shards: [ZERO; NUM_SHARDS],
+            values: OnceLock::new(),
+            metadata: GroupMetadata::new(),
+            entries,
+            lines_per_shard,
         }
     }
 
-    /// Increment the counter by 1.
-    #[inline]
-    pub fn increment(&self) {
-        self.add(1);
+    /// Return the number of entries in this group.
+    pub fn entries(&self) -> usize {
+        self.entries
     }
 
-    /// Add a value to the counter.
-    #[inline]
-    pub fn add(&self, value: u64) {
-        let shard = shard_index();
-        self.shards[shard].value.fetch_add(value, Ordering::Relaxed);
+    fn get_or_init(&self) -> &[CacheLine] {
+        self.values.get_or_init(|| {
+            let total_lines = NUM_SHARDS * self.lines_per_shard;
+            let mut v = Vec::with_capacity(total_lines);
+            for _ in 0..total_lines {
+                #[allow(clippy::declare_interior_mutable_const)]
+                const ZERO: AtomicU64 = AtomicU64::new(0);
+                v.push(CacheLine {
+                    slots: [ZERO; SLOTS_PER_LINE],
+                });
+            }
+            v
+        })
     }
 
-    /// Get the current value (aggregated across all shards).
-    pub fn value(&self) -> u64 {
-        self.shards
-            .iter()
-            .map(|s| s.value.load(Ordering::Relaxed))
-            .sum()
+    #[inline]
+    fn slot(&self, shard: usize, idx: usize) -> &AtomicU64 {
+        let line = shard * self.lines_per_shard + idx / SLOTS_PER_LINE;
+        let slot = idx % SLOTS_PER_LINE;
+        &self.get_or_init()[line].slots[slot]
+    }
+
+    /// Increment the counter at `idx` by 1.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn increment(&self, idx: usize) -> bool {
+        self.add(idx, 1)
+    }
+
+    /// Add `value` to the counter at `idx`.
+    ///
+    /// Returns `false` if `idx` is out of bounds.
+    #[inline]
+    pub fn add(&self, idx: usize, value: u64) -> bool {
+        if idx >= self.entries {
+            return false;
+        }
+        self.slot(shard_index(), idx)
+            .fetch_add(value, Ordering::Relaxed);
+        true
+    }
+
+    /// Load the current value of the counter at `idx` (summed across shards).
+    ///
+    /// Returns `None` if `idx` is out of bounds or values haven't been
+    /// initialized.
+    pub fn value(&self, idx: usize) -> Option<u64> {
+        if idx >= self.entries {
+            return None;
+        }
+        let lines = self.values.get()?;
+        let line_in_shard = idx / SLOTS_PER_LINE;
+        let slot_in_line = idx % SLOTS_PER_LINE;
+        let mut sum: u64 = 0;
+        for shard in 0..NUM_SHARDS {
+            let line = shard * self.lines_per_shard + line_in_shard;
+            sum += lines[line].slots[slot_in_line].load(Ordering::Relaxed);
+        }
+        Some(sum)
+    }
+
+    /// Load all counter values as a snapshot (each summed across shards).
+    ///
+    /// Returns `None` if the group hasn't been initialized yet.
+    pub fn load(&self) -> Option<Vec<u64>> {
+        self.values.get()?;
+        let mut result = Vec::with_capacity(self.entries);
+        for idx in 0..self.entries {
+            result.push(self.value(idx).unwrap_or(0));
+        }
+        Some(result)
+    }
+
+    /// Set metadata for the entry at `idx`.
+    pub fn set_metadata(&self, idx: usize, metadata: HashMap<String, String>) {
+        if idx < self.entries {
+            self.metadata.insert(idx, metadata);
+        }
+    }
+
+    /// Set a single metadata key-value pair for the entry at `idx`.
+    pub fn insert_metadata(&self, idx: usize, key: String, value: String) {
+        if idx < self.entries {
+            self.metadata.insert_kv(idx, key, value);
+        }
+    }
+
+    /// Load metadata for the entry at `idx`.
+    pub fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    /// Remove metadata for the entry at `idx`.
+    pub fn clear_metadata(&self, idx: usize) {
+        self.metadata.remove(idx);
+    }
+
+    /// Snapshot all metadata.
+    pub fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
     }
 }
 
-impl Default for ShardedCounter {
-    fn default() -> Self {
-        Self::new()
+impl CounterGroupMetric for ShardedCounterGroup {
+    fn entries(&self) -> usize {
+        self.entries
+    }
+
+    fn counter_value(&self, idx: usize) -> Option<u64> {
+        self.value(idx)
+    }
+
+    fn load_counters(&self) -> Option<Vec<u64>> {
+        self.load()
+    }
+
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>> {
+        self.metadata.load(idx)
+    }
+
+    fn metadata_snapshot(&self) -> Vec<(usize, HashMap<String, String>)> {
+        self.metadata.snapshot()
     }
 }
 
-impl crate::Metric for ShardedCounter {
+impl Metric for ShardedCounterGroup {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
 
-    fn value(&self) -> Option<crate::Value<'_>> {
-        Some(crate::Value::Counter(self.value()))
+    fn value(&self) -> Option<Value<'_>> {
+        Some(Value::CounterGroup(self))
+    }
+}
+
+impl Default for ShardedCounterGroup {
+    fn default() -> Self {
+        Self::new(1)
     }
 }
 
@@ -118,12 +236,17 @@ mod tests {
 
     #[test]
     fn basic() {
-        static COUNTER: ShardedCounter = ShardedCounter::new();
-        assert_eq!(COUNTER.value(), 0);
-        COUNTER.increment();
-        assert_eq!(COUNTER.value(), 1);
-        COUNTER.add(10);
-        assert_eq!(COUNTER.value(), 11);
+        static GROUP: ShardedCounterGroup = ShardedCounterGroup::new(3);
+        assert_eq!(GROUP.value(0), None);
+        GROUP.increment(0);
+        assert_eq!(GROUP.value(0), Some(1));
+        GROUP.add(1, 10);
+        assert_eq!(GROUP.value(1), Some(10));
+        assert_eq!(GROUP.value(2), Some(0));
+
+        // out of bounds
+        assert!(!GROUP.increment(3));
+        assert_eq!(GROUP.value(3), None);
     }
 
     #[test]
@@ -131,18 +254,19 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        static COUNTER: ShardedCounter = ShardedCounter::new();
-        let counter = Arc::new(&COUNTER);
+        static GROUP: ShardedCounterGroup = ShardedCounterGroup::new(2);
+        let group = Arc::new(&GROUP);
         let iterations: u64 = 1000;
         let num_threads: u64 = 4;
 
         let handles: Vec<_> = (0..num_threads)
             .map(|i| {
-                let c = Arc::clone(&counter);
+                let g = Arc::clone(&group);
                 thread::spawn(move || {
                     set_thread_shard(i as usize);
                     for _ in 0..iterations {
-                        c.increment();
+                        g.increment(0);
+                        g.add(1, 2);
                     }
                 })
             })
@@ -152,17 +276,49 @@ mod tests {
             h.join().unwrap();
         }
 
-        assert_eq!(COUNTER.value(), iterations * num_threads);
+        assert_eq!(GROUP.value(0), Some(iterations * num_threads));
+        assert_eq!(GROUP.value(1), Some(iterations * num_threads * 2));
+    }
+
+    #[test]
+    fn packing() {
+        // 8 counters should fit in one cache line per shard
+        static GROUP: ShardedCounterGroup = ShardedCounterGroup::new(8);
+        assert_eq!(GROUP.lines_per_shard, 1);
+
+        // 9 counters needs two cache lines per shard
+        static GROUP2: ShardedCounterGroup = ShardedCounterGroup::new(9);
+        assert_eq!(GROUP2.lines_per_shard, 2);
+    }
+
+    #[test]
+    fn load_snapshot() {
+        static GROUP: ShardedCounterGroup = ShardedCounterGroup::new(3);
+        GROUP.increment(0);
+        GROUP.add(1, 5);
+        GROUP.add(2, 10);
+
+        let snap = GROUP.load().unwrap();
+        assert_eq!(snap, vec![1, 5, 10]);
+    }
+
+    #[test]
+    fn metadata() {
+        static GROUP: ShardedCounterGroup = ShardedCounterGroup::new(4);
+        GROUP.insert_metadata(0, "op".into(), "read".into());
+        let meta = GROUP.load_metadata(0).unwrap();
+        assert_eq!(meta.get("op").unwrap(), "read");
+        assert!(GROUP.load_metadata(1).is_none());
     }
 
     #[test]
     fn metriken_trait() {
         use crate::Metric;
 
-        static COUNTER: ShardedCounter = ShardedCounter::new();
-        COUNTER.add(42);
+        static GROUP: ShardedCounterGroup = ShardedCounterGroup::new(2);
+        GROUP.increment(0);
 
-        let value = Metric::value(&COUNTER);
-        assert!(matches!(value, Some(crate::Value::Counter(v)) if v >= 42));
+        let value = Metric::value(&GROUP);
+        assert!(matches!(value, Some(Value::CounterGroup(_))));
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,0 @@
-wrap_comments = true
-
-# rust-analyzer generally inserts use statements wherever so this standardizes
-# their order and granularity.
-imports_granularity = "module"
-group_imports = "stdexternalcrate"


### PR DESCRIPTION
## Summary

- Add `CounterGroup`, `GaugeGroup`, `HistogramGroup` with dense value arrays and sparse per-index metadata storage
- Add `ShardedCounterGroup` for contention-free counting — packs up to 8 counters per cache line per shard
- Promote histograms to first-class `Value::Histogram` variant with `HistogramMetric` trait (both `AtomicHistogram` and `RwLockHistogram`)
- Add `Value::CounterGroup`, `Value::GaugeGroup`, `Value::HistogramGroup` variants with corresponding traits in metriken-core
- Add `prometheus_text()` renderer to metriken-exposition
- Update snapshotter to explode group metrics into individual labeled entries
- Only export group entries that have metadata (metadata presence = liveness signal)
- Remove nightly-only rustfmt configuration

## Breaking changes

- `AtomicHistogram` and `RwLockHistogram` now return `Value::Histogram` instead of `Value::Other`. Downstream code matching `Value::Other` for histograms must update to `Value::Histogram(h)` — otherwise histogram exposition silently stops.
- Needs semver-major bump on metriken-core (cascades to metriken).

## Migration

Consumers can replace downcast chains:
```rust
// Before
Some(Value::Other(any)) => {
    if let Some(h) = any.downcast_ref::<AtomicHistogram>() { h.load() }
    else if let Some(h) = any.downcast_ref::<RwLockHistogram>() { h.load() }
}

// After
Some(Value::Histogram(h)) => { h.load() }
```

Or switch to `prometheus_text()` and delete custom renderers entirely.

Custom metric types (e.g., rezolus's BPF mmap-backed CounterGroup) can implement `CounterGroupMetric` / `GaugeGroupMetric` traits from metriken-core to integrate with the exposition layer without using the concrete upstream types.

## Test plan

- [ ] All existing tests pass (86 tests across workspace)
- [ ] New unit tests for CounterGroup, GaugeGroup, HistogramGroup, ShardedCounterGroup
- [ ] Doc tests for all new public types
- [ ] Verify downstream projects (rezolus, crucible, cachecannon, llm-perf) compile after updating match arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)