### PR TITLE
Only export group entries that have metadata

### DIFF
--- a/metriken-exposition/src/prometheus.rs
+++ b/metriken-exposition/src/prometheus.rs
@@ -69,42 +69,51 @@ pub fn prometheus_text(options: &PrometheusOptions) -> String {
             }
             Some(Value::CounterGroup(g)) => {
                 let base_metadata = entry_metadata(metric);
-                if let Some(values) = g.load_counters() {
-                    let mut first = true;
-                    for (idx, &value) in values.iter().enumerate() {
-                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
-                        if first {
-                            write_type_help(&mut output, &name, "counter", metric, options);
-                            first = false;
+                let active = g.metadata_snapshot();
+                if !active.is_empty() {
+                    write_type_help(&mut output, &name, "counter", metric, options);
+                    for (idx, entry_meta) in active {
+                        if let Some(value) = g.counter_value(idx) {
+                            let labels = merge_labels(&base_metadata, Some(entry_meta));
+                            write_metric_line(
+                                &mut output,
+                                &name,
+                                Some(&labels),
+                                &value.to_string(),
+                            );
                         }
-                        write_metric_line(&mut output, &name, Some(&labels), &value.to_string());
                     }
                 }
             }
             Some(Value::GaugeGroup(g)) => {
                 let base_metadata = entry_metadata(metric);
-                if let Some(values) = g.load_gauges() {
-                    let mut first = true;
-                    for (idx, &value) in values.iter().enumerate() {
-                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
-                        if first {
-                            write_type_help(&mut output, &name, "gauge", metric, options);
-                            first = false;
+                let active = g.metadata_snapshot();
+                if !active.is_empty() {
+                    write_type_help(&mut output, &name, "gauge", metric, options);
+                    for (idx, entry_meta) in active {
+                        if let Some(value) = g.gauge_value(idx) {
+                            let labels = merge_labels(&base_metadata, Some(entry_meta));
+                            write_metric_line(
+                                &mut output,
+                                &name,
+                                Some(&labels),
+                                &value.to_string(),
+                            );
                         }
-                        write_metric_line(&mut output, &name, Some(&labels), &value.to_string());
                     }
                 }
             }
             Some(Value::HistogramGroup(g)) => {
                 let base_metadata = entry_metadata(metric);
-                if let Some(hists) = g.load_all_histograms() {
-                    for (idx, snapshot) in hists.iter().enumerate() {
-                        let labels = merge_labels(&base_metadata, g.load_metadata(idx));
+                let active = g.metadata_snapshot();
+                for (idx, entry_meta) in active {
+                    if let Some(snapshot) = g.load_histogram(idx) {
+                        let labels = merge_labels(&base_metadata, Some(entry_meta));
                         write_histogram(
                             &mut output,
                             &name,
                             Some(&labels),
-                            snapshot,
+                            &snapshot,
                             metric,
                             options,
                         );

--- a/metriken-exposition/src/snapshotter.rs
+++ b/metriken-exposition/src/snapshotter.rs
@@ -122,12 +122,10 @@ impl Snapshotter {
                 }
                 Some(Value::CounterGroup(g)) => {
                     let base_metadata = build_metadata(metric);
-                    if let Some(values) = g.load_counters() {
-                        for (idx, &value) in values.iter().enumerate() {
+                    for (idx, entry_meta) in g.metadata_snapshot() {
+                        if let Some(value) = g.counter_value(idx) {
                             let mut metadata = base_metadata.clone();
-                            if let Some(entry_meta) = g.load_metadata(idx) {
-                                metadata.extend(entry_meta);
-                            }
+                            metadata.extend(entry_meta);
                             counters.push(Counter {
                                 name: format!("{column_name}x{idx}"),
                                 value,
@@ -138,12 +136,10 @@ impl Snapshotter {
                 }
                 Some(Value::GaugeGroup(g)) => {
                     let base_metadata = build_metadata(metric);
-                    if let Some(values) = g.load_gauges() {
-                        for (idx, &value) in values.iter().enumerate() {
+                    for (idx, entry_meta) in g.metadata_snapshot() {
+                        if let Some(value) = g.gauge_value(idx) {
                             let mut metadata = base_metadata.clone();
-                            if let Some(entry_meta) = g.load_metadata(idx) {
-                                metadata.extend(entry_meta);
-                            }
+                            metadata.extend(entry_meta);
                             gauges.push(Gauge {
                                 name: format!("{column_name}x{idx}"),
                                 value,
@@ -154,12 +150,10 @@ impl Snapshotter {
                 }
                 Some(Value::HistogramGroup(g)) => {
                     let base_metadata = build_metadata(metric);
-                    if let Some(hists) = g.load_all_histograms() {
-                        for (idx, histogram) in hists.into_iter().enumerate() {
+                    for (idx, entry_meta) in g.metadata_snapshot() {
+                        if let Some(histogram) = g.load_histogram(idx) {
                             let mut metadata = base_metadata.clone();
-                            if let Some(entry_meta) = g.load_metadata(idx) {
-                                metadata.extend(entry_meta);
-                            }
+                            metadata.extend(entry_meta);
                             metadata.insert(
                                 "grouping_power".to_string(),
                                 histogram.config().grouping_power().to_string(),


### PR DESCRIPTION
## Summary

- Use metadata presence as the liveness signal for group metric entries
- Snapshotter and Prometheus renderer now iterate `metadata_snapshot()` instead of all entries
- Entries without metadata are skipped during export

This avoids exporting thousands of empty slots in large pre-allocated groups (e.g., per-cgroup counters with 4096 slots, per-PID counters with 4M slots). Instead of a sentinel value like `i64::MIN`, consumers activate a slot by calling `set_metadata()` / `insert_metadata()` and deactivate it with `clear_metadata()`.

## Test plan

- [ ] All existing tests pass (89 tests across workspace)
- [ ] Verify rezolus exposition only exports active cgroup/task entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)