### PR TITLE
prepare for release: bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metriken"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-core"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "histogram",
  "linkme",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-core/Cargo.toml
+++ b/metriken-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-core"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-exposition/Cargo.toml
+++ b/metriken-exposition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-exposition"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -15,7 +15,7 @@ repository = "https://github.com/iopsystems/metriken"
 arrow = { version = "56.1.0", optional = true }
 chrono = "0.4.38"
 histogram = "1.0.0"
-metriken = { version = "0.8.0", path = "../metriken" }
+metriken = { version = "0.9.0", path = "../metriken" }
 parquet = { version = "56.1.0", optional = true }
 rmp-serde = { version = "1.3.0", optional = true }
 serde = { version = "1.0.218", features = ["derive"], optional = true }

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.7.0"
+version = "0.9.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
@@ -14,7 +14,7 @@ repository = "https://github.com/iopsystems/metriken"
 arrow = "56.1.0"
 bytes = "1"
 histogram = "1.0.0"
-metriken-exposition = { version = "0.14.0", path = "../metriken-exposition", default-features = false, optional = true }
+metriken-exposition = { version = "0.15.0", path = "../metriken-exposition", default-features = false, optional = true }
 parquet = { version = "56.1.0", default-features = false, features = ["arrow", "snap", "brotli", "flate2", "flate2-rust_backened", "zstd"] }
 promql-parser = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Brian Martin <brian@iop.systems>", "Sean Lynch <sean@iop.systems>"]
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-metriken-core   = { version = "0.1",    path = "../metriken-core" }
+metriken-core   = { version = "0.2",    path = "../metriken-core" }
 metriken-derive = { version = "=0.5.1", path = "../metriken-derive" }
 
 histogram = "1.0.0"


### PR DESCRIPTION
## Summary

- **metriken-core**: 0.1.3 → 0.2.0 — breaking: new `Value` variants (`Histogram`, `CounterGroup`, `GaugeGroup`, `HistogramGroup`), new traits module, lifetime change on `Metric::value()`
- **metriken**: 0.8.0 → 0.9.0 — new `CounterGroup`, `GaugeGroup`, `HistogramGroup` types, `attach_external` for counter/gauge groups, `AtomicHistogram`/`RwLockHistogram`
- **metriken-exposition**: 0.14.0 → 0.15.0 — grouped metrics exposition, conditional metadata-only export
- **metriken-query**: 0.7.0 → 0.9.0 — dependency version updates (0.8.0 already taken on crates.io)
- **metriken-derive**: unchanged at 0.5.1

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (all 100+ tests green)
- [x] Publish in dependency order: metriken-core → metriken → metriken-exposition → metriken-query

🤖 Generated with [Claude Code](https://claude.com/claude-code)