### PR TITLE
fix: remove cpu_cores scalar special case in vector selector

### DIFF
--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -1316,16 +1316,6 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                 // Handle simple metric selection - return all series with their labels
                 // Check for gauges first
                 if let Some(collection) = self.tsdb.gauges(metric_name, Labels::default()) {
-                    // Special case for cpu_cores - return as scalar
-                    if metric_name == "cpu_cores" {
-                        let sum_series = collection.filtered_sum(&Labels::default());
-                        if let Some((_ts, value)) = sum_series.inner.iter().next() {
-                            return Ok(QueryResult::Scalar {
-                                result: (start, *value),
-                            });
-                        }
-                    }
-
                     let start_ns = (start * 1e9) as u64;
                     let end_ns = (end * 1e9) as u64;
                     let step_ns = (step * 1e9) as u64;


### PR DESCRIPTION
## Summary

The PromQL vector selector evaluator had a hardcoded special case for `cpu_cores` that collapsed its time series into a single `Scalar` result. This broke frontend visualization, which expects a normal time series like any other gauge.

This change removes the special case so `cpu_cores` (and any similarly-shaped gauge) now flows through the standard gauge path and returns a `Matrix` of samples over the requested range.

## Changes

- `metriken-query/src/promql/mod.rs`: drop the `if metric_name == "cpu_cores"` short-circuit inside `Expr::VectorSelector` evaluation.

## Test plan

- [x] `cargo build -p metriken-query`
- [x] `cargo test -p metriken-query` (30 passed)
- [ ] Verify frontend visualization renders `cpu_cores` as a time series
