### PR TITLE
chore: bump metriken-query to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

Bump `metriken-query` from `0.9.0` to `0.9.1` (patch revision).

## Test plan

- [x] `cargo update -p metriken-query` reflects the new version in `Cargo.lock`
