### PR TITLE
fix(query): snap TSDB timestamps to sampling interval boundaries

### DIFF
--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -1330,28 +1330,25 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                             continue;
                         }
                         let untyped = series.untyped();
-                        let values: Vec<(f64, f64)> = if step_ns > interval_ns {
-                            // Step is coarser than native interval:
-                            // evaluate at step-aligned timestamps
+                        // Always evaluate at step-aligned timestamps so
+                        // gauge results can participate in binary operations
+                        // with other step-aligned series (e.g. irate
+                        // results).
+                        let staleness = step_ns.max(interval_ns);
+                        let values: Vec<(f64, f64)> = {
                             let mut vals = Vec::new();
                             let mut current = start_ns;
                             while current <= end_ns {
                                 if let Some((&ts, &val)) =
                                     untyped.inner.range(..=current).next_back()
                                 {
-                                    if current - ts <= step_ns {
+                                    if current - ts <= staleness {
                                         vals.push((current as f64 / 1e9, val));
                                     }
                                 }
                                 current += step_ns;
                             }
                             vals
-                        } else {
-                            untyped
-                                .inner
-                                .range(start_ns..=end_ns)
-                                .map(|(ts, val)| (*ts as f64 / 1e9, *val))
-                                .collect()
                         };
 
                         if !values.is_empty() {

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -23,6 +23,17 @@ pub use heatmap::Heatmap;
 pub use labels::Labels;
 pub use series::*;
 
+/// Snap a nanosecond timestamp to the nearest multiple of `interval_ns`.
+/// Returns the timestamp unchanged when `interval_ns` is zero (i.e. unknown).
+#[allow(clippy::manual_checked_ops)]
+fn snap_timestamp(ts: u64, interval_ns: u64) -> u64 {
+    if interval_ns > 0 {
+        ((ts + interval_ns / 2) / interval_ns) * interval_ns
+    } else {
+        ts
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct Tsdb {
     sampling_interval_ms: u64,
@@ -106,9 +117,21 @@ impl Tsdb {
                         .downcast_ref::<UInt64Array>()
                         .expect("Failed to downcast");
 
+                    let interval_ns = data.sampling_interval_ms * 1_000_000;
+
                     for (id, value) in values.iter().enumerate() {
                         if let Some(v) = value {
-                            timestamps.insert(id, v);
+                            // Snap timestamps to the nearest multiple of the
+                            // sampling interval.  Different samplers may fire
+                            // at slightly different wall-clock times within
+                            // the same collection cycle, so their raw
+                            // timestamps can diverge by microseconds.
+                            // Aligning here ensures that binary operations
+                            // between metrics from different samplers (e.g.
+                            // `irate(cpu_usage) / cpu_cores`) find matching
+                            // timestamps.
+                            let snapped = snap_timestamp(v, interval_ns);
+                            timestamps.insert(id, snapped);
                         }
                     }
 
@@ -258,11 +281,17 @@ impl Tsdb {
     /// TSDB.
     #[cfg(feature = "ingest")]
     pub fn ingest(&mut self, mut snapshot: metriken_exposition::Snapshot) {
-        let ts = snapshot
+        let raw_ts = snapshot
             .systemtime()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .expect("system clock is earlier than 1970")
             .as_nanos() as u64;
+
+        // Snap to the nearest sampling interval boundary so that metrics
+        // from different samplers within the same collection cycle share
+        // an identical timestamp.
+        let interval_ns = self.sampling_interval_ms * 1_000_000;
+        let ts = snap_timestamp(raw_ts, interval_ns);
 
         for counter in snapshot.counters() {
             let (name, labels) = Self::extract_name_labels(&counter.metadata);


### PR DESCRIPTION
## Summary

- Snap all TSDB timestamps to the nearest multiple of the sampling interval at ingest time (both parquet load and live snapshot paths)
- Eliminates spurious null values when PromQL binary operations combine metrics from different samplers (e.g. `irate(cpu_usage) / cpu_cores`) whose raw timestamps diverge by microseconds within the same collection cycle
- Simplifies the gauge vector selector to always use step-aligned evaluation, removing the conditional branch that fell through to raw TSDB timestamps at native resolution

## Test plan

- [x] All 30 existing metriken-query tests pass
- [x] Clippy clean (no new warnings)
- [ ] Verify in rezolus viewer: CPU utilization queries at 1s step no longer show null gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)