### PR TITLE
chore: bump metriken-query to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

- Bump metriken-query version to 0.9.2 for release after timestamp alignment fix (#80)

## Test plan

- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)