### PR TITLE
fix(query): strip internal metadata from parquet column labels

### DIFF
--- a/docs/structured-column-metadata.md
+++ b/docs/structured-column-metadata.md
@@ -1,0 +1,62 @@
+# Structured Column Metadata
+
+## Status: Future Design Change
+
+## Problem
+
+Arrow field metadata on parquet metric columns currently uses a flat
+`HashMap<String, String>` that mixes metric properties with user-facing
+labels:
+
+```
+{
+  "metric": "cpu_usage",
+  "metric_type": "counter",
+  "unit": "nanoseconds",
+  "state": "user",
+  "id": "0"
+}
+```
+
+The TSDB reader must maintain a skip list of internal keys (`metric`,
+`metric_type`, `unit`, `grouping_power`, `max_value_power`) to avoid
+leaking them as PromQL labels. This is fragile — every new metadata
+field requires updating the skip list in every reader.
+
+## Proposed Solution
+
+Separate metric properties from labels with a structured schema:
+
+```
+{
+  "metric": "cpu_usage",
+  "metric_type": "counter",
+  "unit": "nanoseconds",
+  "labels": "{\"state\":\"user\",\"id\":\"0\"}"
+}
+```
+
+The `labels` value is a JSON-encoded map since Arrow field metadata
+values are strings. The reader parses `labels` to build the TSDB label
+set and ignores all other keys — no skip list needed.
+
+## Migration
+
+Backward compatibility via version detection:
+
+- If a `labels` key is present in field metadata, use the structured
+  path (parse JSON, ignore everything else).
+- If absent, fall back to the current flat-bag behavior with the skip
+  list.
+
+This allows old parquet files to load without modification while new
+recordings use the clean format.
+
+## Affected Crates
+
+- **metriken-exposition** (`src/parquet.rs`): writes field metadata when
+  producing parquet files.
+- **metriken-query** (`src/tsdb/mod.rs`): reads field metadata when
+  loading parquet into the TSDB.
+- **rezolus** (`src/parquet_tools/combine.rs`): copies and merges field
+  metadata when combining multi-source files.

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -169,7 +169,13 @@ impl Tsdb {
                 let mut labels = Labels::default();
 
                 for (k, v) in meta.iter() {
-                    labels.inner.insert(k.to_string(), v.to_string());
+                    match k.as_str() {
+                        // Internal metadata — not user-facing labels
+                        "metric" | "metric_type" | "unit" => continue,
+                        _ => {
+                            labels.inner.insert(k.to_string(), v.to_string());
+                        }
+                    }
                 }
 
                 let column = batch.column(id);


### PR DESCRIPTION
## Summary

- Strip `metric_type`, `metric`, and `unit` from Arrow field metadata before building TSDB labels in the parquet load path
- These are internal metadata used for type dispatch (counter/gauge/histogram) and should not leak into PromQL as queryable labels
- Aligns the parquet path with the live ingest path, which already skips these keys

Without this fix, every series loaded from parquet carries a spurious `metric_type` label (e.g. `metric_type="counter"`), which can cause unexpected behavior in label-aware operations like `sum by` or binary ops between metrics of different types.

## Test plan

- [x] All 30 existing metriken-query tests pass
- [x] Clippy clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)