### PR TITLE
fix: initialize GaugeGroup entries to i64::MIN sentinel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metriken"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "histogram",
  "metriken-core",

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Brian Martin <brian@iop.systems>", "Sean Lynch <sean@iop.systems>"]
 license = "Apache-2.0"

--- a/metriken/src/group/gauge.rs
+++ b/metriken/src/group/gauge.rs
@@ -81,7 +81,7 @@ impl GaugeGroup {
             .get_or_init(|| {
                 let mut v = Vec::with_capacity(self.entries);
                 for _ in 0..self.entries {
-                    v.push(AtomicI64::new(0));
+                    v.push(AtomicI64::new(i64::MIN));
                 }
                 Backing::Owned(v)
             })

--- a/metriken/src/group/gauge.rs
+++ b/metriken/src/group/gauge.rs
@@ -106,17 +106,34 @@ impl GaugeGroup {
 
     /// Add `value` to the gauge at `idx`.
     ///
+    /// If the entry has not been initialized yet, it is treated as `0` before
+    /// the addition.
+    ///
     /// Returns `false` if `idx` is out of bounds.
     #[inline]
     pub fn add(&self, idx: usize, value: i64) -> bool {
         if idx >= self.entries {
             return false;
         }
-        self.get_or_init()[idx].fetch_add(value, Ordering::Relaxed);
-        true
+        let atomic = &self.get_or_init()[idx];
+        let mut current = atomic.load(Ordering::Relaxed);
+        loop {
+            let new = if current == i64::MIN {
+                value
+            } else {
+                current.wrapping_add(value)
+            };
+            match atomic.compare_exchange_weak(current, new, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
+        }
     }
 
     /// Subtract `value` from the gauge at `idx`.
+    ///
+    /// If the entry has not been initialized yet, it is treated as `0` before
+    /// the subtraction.
     ///
     /// Returns `false` if `idx` is out of bounds.
     #[inline]
@@ -124,8 +141,19 @@ impl GaugeGroup {
         if idx >= self.entries {
             return false;
         }
-        self.get_or_init()[idx].fetch_sub(value, Ordering::Relaxed);
-        true
+        let atomic = &self.get_or_init()[idx];
+        let mut current = atomic.load(Ordering::Relaxed);
+        loop {
+            let new = if current == i64::MIN {
+                value.wrapping_neg()
+            } else {
+                current.wrapping_sub(value)
+            };
+            match atomic.compare_exchange_weak(current, new, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
+        }
     }
 
     /// Set the gauge at `idx` to `value`.
@@ -141,15 +169,16 @@ impl GaugeGroup {
 
     /// Load the current value of the gauge at `idx`.
     ///
-    /// Returns `None` if `idx` is out of bounds or values haven't been
-    /// initialized.
+    /// Returns `None` if `idx` is out of bounds, values haven't been
+    /// initialized, or the entry has not been written to yet.
     pub fn value(&self, idx: usize) -> Option<i64> {
         if idx >= self.entries {
             return None;
         }
-        self.values
-            .get()
-            .map(|b| b.as_slice()[idx].load(Ordering::Relaxed))
+        self.values.get().and_then(|b| {
+            let v = b.as_slice()[idx].load(Ordering::Relaxed);
+            (v != i64::MIN).then_some(v)
+        })
     }
 
     /// Load all gauge values as a snapshot.


### PR DESCRIPTION
## Summary
- `GaugeGroup::get_or_init` now initializes owned backing entries with `i64::MIN` instead of `0`, making uninitialized state observable (fixes the sentinel bug at `metriken/src/group/gauge.rs:82-86`).
- `GaugeGroup::value(idx)` returns `None` when the entry is still the `i64::MIN` sentinel.
- `GaugeGroup::add` / `sub` use a `compare_exchange_weak` loop: on an uninitialized entry they CAS-initialize from `0` (to `value` / `-value`); otherwise they wrapping-add/sub as before.
- `set` and `load` are unchanged. `load` still returns `Vec<i64>` including any sentinel entries — per-entry `None` would require changing the trait signature, so that's out of scope here.
- Bumps `metriken` patch version to `0.9.2`.

## Caveats
- `i64::MIN` is now a reserved sentinel and cannot be stored as a legitimate gauge value through these APIs. External backings must not seed entries with `i64::MIN` if they should be observable via `value()`.

## Test plan
- [x] `cargo test -p metriken` (20/20 passing locally, including the existing `basic_operations` test which now exercises the CAS-initialize path on an unset entry)
- [x] `cargo fmt --check -p metriken`
- [x] `cargo clippy -p metriken --all-targets -- -D warnings`
- [ ] CI: ubuntu / macos / windows / clippy / rustfmt / check-powerset