### PR TITLE
feat(query): support on()/ignoring() label-matching modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `metriken-query`: support PromQL `on(...)` and `ignoring(...)` label-matching
+  modifiers on binary operators, allowing expressions whose operands carry
+  mismatched label sets (e.g. `tx_bytes / ignoring(direction) link_bandwidth`)
+  to combine correctly.
+
 ### 0.5.1
 Metriken versions older than 0.5.1 did not have changelogs.

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -153,6 +153,47 @@ fn extract_filter_labels(matchers: &[Matcher]) -> Labels {
     filter_labels
 }
 
+/// Build the label set used to match two series in a binary operation, honoring
+/// any `on(...)` / `ignoring(...)` modifier attached to the binary expression.
+///
+/// When no modifier is supplied the match key is the full label set with the
+/// reserved `__name__` label dropped (this is the historical behavior). With
+/// `on(labels)` only the listed labels participate in matching; with
+/// `ignoring(labels)` every label except the listed ones (and `__name__`)
+/// participates. This lets operators combine series with otherwise mismatched
+/// label sets — e.g. `tx_bytes / ignoring(direction) link_bandwidth` where the
+/// tx/rx series carries a `direction` label that the bandwidth series does not.
+fn match_key(
+    metric: &HashMap<String, String>,
+    matching: Option<&parser::LabelModifier>,
+) -> BTreeMap<String, String> {
+    let mut key = BTreeMap::new();
+    match matching {
+        Some(parser::LabelModifier::Include(labels)) => {
+            for label_name in &labels.labels {
+                if let Some(value) = metric.get(label_name) {
+                    key.insert(label_name.clone(), value.clone());
+                }
+            }
+        }
+        Some(parser::LabelModifier::Exclude(labels)) => {
+            for (k, v) in metric {
+                if k != "__name__" && !labels.labels.contains(k) {
+                    key.insert(k.clone(), v.clone());
+                }
+            }
+        }
+        None => {
+            for (k, v) in metric {
+                if k != "__name__" {
+                    key.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+    key
+}
+
 impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
     pub fn new(tsdb: T) -> Self {
         Self { tsdb }
@@ -1107,6 +1148,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         op: &TokenType,
         left: QueryResult,
         right: QueryResult,
+        modifier: Option<&parser::BinModifier>,
     ) -> Result<QueryResult, QueryError> {
         match (left, right) {
             // Both sides are matrices (time series)
@@ -1119,42 +1161,29 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                 },
             ) => {
                 let mut result_samples = Vec::new();
+                let matching = modifier.and_then(|m| m.matching.as_ref());
 
-                // Build a map of right samples by their label set for efficient matching
+                // Build a map of right samples by their matching label set
                 let mut right_by_labels: HashMap<BTreeMap<String, String>, &MatrixSample> =
                     HashMap::new();
                 for right_sample in &right_samples {
-                    // Extract labels (excluding __name__)
-                    let mut labels = BTreeMap::new();
-                    for (k, v) in &right_sample.metric {
-                        if k != "__name__" {
-                            labels.insert(k.clone(), v.clone());
-                        }
-                    }
+                    let labels = match_key(&right_sample.metric, matching);
                     right_by_labels.insert(labels, right_sample);
                 }
 
                 for left_sample in &left_samples {
-                    // Extract labels from left sample (excluding __name__)
-                    let mut left_labels = BTreeMap::new();
-                    for (k, v) in &left_sample.metric {
-                        if k != "__name__" {
-                            left_labels.insert(k.clone(), v.clone());
-                        }
-                    }
+                    let left_labels = match_key(&left_sample.metric, matching);
 
                     // Find matching right sample by labels
-                    let right_sample = if left_labels.is_empty() && right_samples.len() == 1 {
-                        // Special case: if left has no labels and right has only one series, use it
-                        right_samples.first()
-                    } else if right_samples.len() == 1 {
-                        // If right has only one series, use it regardless of labels
-                        // (common case for single-metric operations)
+                    let right_sample = if let Some(matched) = right_by_labels.get(&left_labels) {
+                        Some(*matched)
+                    } else if matching.is_none() && right_samples.len() == 1 {
+                        // No explicit matcher and right has a single series: fall back to it.
+                        // This preserves the common case of combining a vector with a
+                        // single-series metric or aggregate without specifying matchers.
                         right_samples.first()
                     } else {
-                        // Match by labels
-                        let matched = right_by_labels.get(&left_labels).copied();
-                        matched
+                        None
                     };
 
                     if let Some(right_sample) = right_sample {
@@ -1302,8 +1331,8 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                 let left = self.evaluate_expr(&binary.lhs, start, end, step)?;
                 let right = self.evaluate_expr(&binary.rhs, start, end, step)?;
 
-                // Apply the binary operation
-                self.apply_binary_op(&binary.op, left, right)
+                // Apply the binary operation, honoring any on()/ignoring() modifier
+                self.apply_binary_op(&binary.op, left, right, binary.modifier.as_ref())
             }
             Expr::VectorSelector(selector) => {
                 // Handle simple metric selection

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -873,3 +873,145 @@ fn test_triple_gauge_expression_respects_step() {
     assert!((all_values[0][2].0 - 1004.0).abs() < 1e-6);
     assert!((all_values[0][2].1 - 550.0).abs() < 1e-6); // (1000-400)-50
 }
+
+/// Build a TSDB modeling a duplex link: per-direction traffic counters and a
+/// per-interface bandwidth gauge. Traffic carries a `direction` label that the
+/// bandwidth series does not, so combining them requires on()/ignoring().
+///
+///   tx_bytes{iface="eth0", direction="tx"} = 100 at each step
+///   tx_bytes{iface="eth1", direction="tx"} = 200 at each step
+///   link_bandwidth{iface="eth0"} = 1000 at each step
+///   link_bandwidth{iface="eth1"} = 2000 at each step
+fn create_duplex_tsdb() -> Tsdb {
+    use metriken_exposition::{Gauge, Snapshot, SnapshotV2};
+
+    let mut tsdb = Tsdb::default();
+    let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+
+    for step in 0u64..3 {
+        let time = base_time + Duration::from_secs(step);
+        let mut gauges = Vec::new();
+
+        for (iface, tx_val) in [("eth0", 100i64), ("eth1", 200i64)] {
+            let mut meta = HashMap::new();
+            meta.insert("metric".to_string(), "tx_bytes".to_string());
+            meta.insert("iface".to_string(), iface.to_string());
+            meta.insert("direction".to_string(), "tx".to_string());
+            gauges.push(Gauge {
+                name: "tx_bytes".to_string(),
+                value: tx_val,
+                metadata: meta,
+            });
+        }
+
+        for (iface, bw) in [("eth0", 1000i64), ("eth1", 2000i64)] {
+            let mut meta = HashMap::new();
+            meta.insert("metric".to_string(), "link_bandwidth".to_string());
+            meta.insert("iface".to_string(), iface.to_string());
+            gauges.push(Gauge {
+                name: "link_bandwidth".to_string(),
+                value: bw,
+                metadata: meta,
+            });
+        }
+
+        let snapshot = Snapshot::V2(SnapshotV2 {
+            systemtime: time,
+            duration: Duration::from_secs(1),
+            metadata: HashMap::new(),
+            counters: Vec::new(),
+            gauges,
+            histograms: Vec::new(),
+        });
+        tsdb.ingest(snapshot);
+    }
+
+    tsdb
+}
+
+fn series_for_iface(result: &QueryResult, iface: &str) -> Option<Vec<(f64, f64)>> {
+    match result {
+        QueryResult::Matrix { result } => result
+            .iter()
+            .find(|s| s.metric.get("iface").map(|v| v.as_str()) == Some(iface))
+            .map(|s| s.values.clone()),
+        _ => None,
+    }
+}
+
+#[test]
+fn test_ignoring_matches_mismatched_labels() {
+    // tx_bytes has {iface, direction}; link_bandwidth has only {iface}. With
+    // ignoring(direction) the series are matched pairwise by iface, giving
+    // tx_bytes / link_bandwidth per interface.
+    let tsdb = Arc::new(create_duplex_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range(
+            "tx_bytes / ignoring(direction, metric) link_bandwidth",
+            1000.0,
+            1002.0,
+            1.0,
+        )
+        .unwrap();
+
+    assert_eq!(count_matrix_series(&result), 2, "expected one series per iface");
+
+    let eth0 = series_for_iface(&result, "eth0").expect("eth0 series");
+    let eth1 = series_for_iface(&result, "eth1").expect("eth1 series");
+
+    assert_eq!(eth0.len(), 3);
+    for (_, v) in &eth0 {
+        assert!((v - 0.1).abs() < 1e-9, "eth0: 100/1000 = 0.1, got {v}");
+    }
+
+    assert_eq!(eth1.len(), 3);
+    for (_, v) in &eth1 {
+        assert!((v - 0.1).abs() < 1e-9, "eth1: 200/2000 = 0.1, got {v}");
+    }
+}
+
+#[test]
+fn test_on_matches_shared_labels() {
+    // Same shape as ignoring(), but expressed with on(iface).
+    let tsdb = Arc::new(create_duplex_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range(
+            "tx_bytes / on(iface) link_bandwidth",
+            1000.0,
+            1002.0,
+            1.0,
+        )
+        .unwrap();
+
+    assert_eq!(count_matrix_series(&result), 2);
+
+    let eth0 = series_for_iface(&result, "eth0").expect("eth0 series");
+    let eth1 = series_for_iface(&result, "eth1").expect("eth1 series");
+
+    for (_, v) in &eth0 {
+        assert!((v - 0.1).abs() < 1e-9);
+    }
+    for (_, v) in &eth1 {
+        assert!((v - 0.1).abs() < 1e-9);
+    }
+}
+
+#[test]
+fn test_mismatched_labels_without_modifier_do_not_match() {
+    // Without a matching modifier, and with multiple series on both sides,
+    // mismatched label sets produce no pairings — confirming that ignoring()
+    // is doing real work in the tests above rather than being papered over
+    // by the single-series fallback.
+    let tsdb = Arc::new(create_duplex_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("tx_bytes / link_bandwidth", 1000.0, 1002.0, 1.0)
+        .unwrap();
+
+    assert_eq!(count_matrix_series(&result), 0);
+}

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -956,7 +956,11 @@ fn test_ignoring_matches_mismatched_labels() {
         )
         .unwrap();
 
-    assert_eq!(count_matrix_series(&result), 2, "expected one series per iface");
+    assert_eq!(
+        count_matrix_series(&result),
+        2,
+        "expected one series per iface"
+    );
 
     let eth0 = series_for_iface(&result, "eth0").expect("eth0 series");
     let eth1 = series_for_iface(&result, "eth1").expect("eth1 series");
@@ -979,12 +983,7 @@ fn test_on_matches_shared_labels() {
     let engine = QueryEngine::new(tsdb);
 
     let result = engine
-        .query_range(
-            "tx_bytes / on(iface) link_bandwidth",
-            1000.0,
-            1002.0,
-            1.0,
-        )
+        .query_range("tx_bytes / on(iface) link_bandwidth", 1000.0, 1002.0, 1.0)
         .unwrap();
 
     assert_eq!(count_matrix_series(&result), 2);


### PR DESCRIPTION
## Summary

- Honors the PromQL `on(...)` / `ignoring(...)` modifiers that `promql-parser` already parses but `metriken-query` had been dropping. This lets queries combine series with mismatched labels — e.g. `tx_bytes / ignoring(direction) link_bandwidth` for per-interface utilization on a duplex link.
- Centralizes binary-op label matching through a new `match_key` helper (drops `__name__` by default, filters per `Include` / `Exclude`). The previous "always match when RHS has one series" fallback is preserved only when no modifier is supplied, so explicit modifiers get strict semantics.
- Adds three tests exercising `ignoring()`, `on()`, and the no-modifier mismatch case against a duplex-link fixture.

## Test plan

- [x] `cargo test -p metriken-query --lib` — 33 tests pass, including the new `test_ignoring_matches_mismatched_labels`, `test_on_matches_shared_labels`, and `test_mismatched_labels_without_modifier_do_not_match`.
- [x] `cargo test --workspace` — all suites pass.
- [ ] Exercise `tx / ignoring(direction) link_bandwidth` against real parquet data.

https://claude.ai/code/session_01Ar3E6KhFbJoWsRRBEGoTNJ