### PR TITLE
chore: bump metriken-query to 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `metriken-query`: support PromQL `on(...)` and `ignoring(...)` label-matching
-  modifiers on binary operators, allowing expressions whose operands carry
-  mismatched label sets (e.g. `tx_bytes / ignoring(direction) link_bandwidth`)
-  to combine correctly.
+### metriken-query 0.9.4
+
+- Support PromQL `on(...)` and `ignoring(...)` label-matching modifiers on
+  binary operators, allowing expressions whose operands carry mismatched label
+  sets (e.g. `tx_bytes / ignoring(direction) link_bandwidth`) to combine
+  correctly.
 
 ### 0.5.1
 Metriken versions older than 0.5.1 did not have changelogs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

- Bumps `metriken-query` 0.9.3 → 0.9.4 to release the `on()` / `ignoring()` label-matching support added in #86.
- Updates `Cargo.lock` and moves the feature's `CHANGELOG.md` entry under a `metriken-query 0.9.4` heading.
- No other crate in the workspace has pending changes since the last version bump — `metriken-core`, `metriken-derive`, `metriken-exposition` are untouched and `metriken` was already bumped to 0.9.2 in #85.

## Test plan

- [x] `cargo test -p metriken-query --lib` — 33 tests pass.
- [ ] Confirm crates.io publish goes through once merged.

https://claude.ai/code/session_01Ar3E6KhFbJoWsRRBEGoTNJ