### PR TITLE
chore: bump metriken-query to 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### metriken-query 0.9.5
+
+- Store histograms in the TSDB as `CumulativeROHistogram`, which only retains
+  non-zero buckets in columnar form. This substantially reduces memory usage
+  for sparse distributions and lets quantile queries run as a binary search on
+  the cumulative counts. Delta and sum between two `CumulativeROHistogram`s
+  are computed via a shared `combine()` helper.
+
 ### metriken-query 0.9.4
 
 - Support PromQL `on(...)` and `ignoring(...)` label-matching modifiers on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

Patch release of `metriken-query` bumping from 0.9.4 to 0.9.5.

Picks up the only unreleased change since 0.9.4:

- #88 — Store histograms in the TSDB as `CumulativeROHistogram`, reducing
  memory usage for sparse distributions and letting quantile queries run as a
  binary search on the cumulative counts.

No other workspace crates have unreleased changes, so only `metriken-query` is
bumped.

## Test plan

- [x] `cargo check -p metriken-query` passes
- [ ] CI is green on this PR

https://claude.ai/code/session_016J5daWAdxvpQeT5EtW7zui