### PR TITLE
chore: bump metriken-query to 0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "arrow",
  "axum",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "metriken-query"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",
+    "Yao Yue <yao@iop.systems>",
 ]
 license = "MIT OR Apache-2.0"
 description = "PromQL query engine and TSDB for metriken parquet files"


### PR DESCRIPTION
Bumps `metriken-query` from `0.9.5` → `0.9.6` to publish the changes from #90 (delta/u32/Vec/CSR storage refactor + streaming column-by-column parquet decode + zero-alloc query path; see that PR's description for the per-technique breakdown and savings table).

Also adds Yao Yue <yao@iop.systems> to the crate's `authors` list.

No code changes beyond `Cargo.toml` / `Cargo.lock`.

https://claude.ai/code/session_019SFvQ81oHW3WnWbW7CXtuF

---
_Generated by [Claude Code](https://claude.ai/code/session_019SFvQ81oHW3WnWbW7CXtuF)_