### PR TITLE
prototype streaming time-series pipeline (irate + sum by)

### DIFF
--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -13,6 +13,8 @@ use crate::tsdb::{GaugeSeries, Labels, Tsdb, UntypedCollection, UntypedSeries};
 #[cfg(feature = "http")]
 mod api;
 
+pub mod streaming;
+
 #[cfg(test)]
 mod tests;
 

--- a/metriken-query/src/promql/streaming/irate.rs
+++ b/metriken-query/src/promql/streaming/irate.rs
@@ -1,0 +1,80 @@
+//! `irate` as a pull-based iterator over a counter sample slice.
+//!
+//! Mirrors `CounterSeries::windowed_irate` exactly — at each step
+//! tick, locate the last two samples in `[t - range, t]` and emit
+//! `(t, delta / duration)`. The only state held is the cursor; the
+//! sample slice is borrowed from the TSDB.
+
+use super::Point;
+
+pub struct CounterIrate<'a> {
+    samples: &'a [(u64, u64)],
+    cursor_ns: u64,
+    end_ns: u64,
+    step_ns: u64,
+    range_ns: u64,
+    /// Set once the cursor would overflow past `end_ns`. Without this
+    /// flag, a `step_ns` of 0 would loop forever; we treat that as a
+    /// caller bug but still bail cleanly.
+    done: bool,
+}
+
+impl<'a> CounterIrate<'a> {
+    pub fn new(
+        samples: &'a [(u64, u64)],
+        start_ns: u64,
+        end_ns: u64,
+        step_ns: u64,
+        range_ns: u64,
+    ) -> Self {
+        Self {
+            samples,
+            cursor_ns: start_ns,
+            end_ns,
+            step_ns,
+            range_ns,
+            done: step_ns == 0,
+        }
+    }
+}
+
+impl<'a> Iterator for CounterIrate<'a> {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Point> {
+        while !self.done && self.cursor_ns <= self.end_ns {
+            let t = self.cursor_ns;
+            // Advance for the next call. Saturating to avoid wrapping
+            // past u64::MAX; the `self.cursor_ns <= self.end_ns` gate
+            // above will catch the saturated case on the next tick.
+            match self.cursor_ns.checked_add(self.step_ns) {
+                Some(next) => self.cursor_ns = next,
+                None => self.done = true,
+            }
+
+            let window_start = t.saturating_sub(self.range_ns);
+            let lo = self.samples.partition_point(|&(ts, _)| ts < window_start);
+            let hi = self.samples.partition_point(|&(ts, _)| ts <= t);
+            if hi.saturating_sub(lo) < 2 {
+                continue;
+            }
+
+            let (ts_cur, v_cur) = self.samples[hi - 1];
+            let (ts_prev, v_prev) = self.samples[hi - 2];
+            let delta = if v_cur >= v_prev {
+                (v_cur - v_prev) as f64
+            } else {
+                // Counter reset: PromQL irate treats the reset point's
+                // own value as the increase.
+                v_cur as f64
+            };
+            let dur_s = (ts_cur - ts_prev) as f64 / 1e9;
+            if dur_s <= 0.0 {
+                continue;
+            }
+
+            return Some((t, delta / dur_s));
+        }
+        None
+    }
+}

--- a/metriken-query/src/promql/streaming/mod.rs
+++ b/metriken-query/src/promql/streaming/mod.rs
@@ -1,0 +1,119 @@
+//! Streaming time-series model (prototype).
+//!
+//! The eager pipeline materialises every intermediate stage as
+//! `Vec<(f64, f64)>`. For the WASM viewer this means a typical
+//! `sum by (label) (irate(metric[5s]))` over many series produces a
+//! transient `O(stages × points × series)` heap footprint just to be
+//! reduced down to `O(stages × points)` at the boundary.
+//!
+//! This module replaces the in-flight matrices with iterator pipelines:
+//!
+//! * [`Point`] — the single sample carried through the pipeline.
+//! * [`LabeledSeries`] — labelset + boxed iterator yielding `Point`.
+//! * Operators (e.g. [`CounterIrate`], [`SumMerge`]) wrap upstream
+//!   iterators and pull lazily, holding only their own windowed state.
+//!
+//! Only `irate` and `sum by` are wired up here; the rest of the engine
+//! still uses the eager path. The intent of this module is to validate
+//! the model end-to-end (parity-tested against the eager path) before
+//! migrating the remaining operators.
+
+use std::collections::HashMap;
+
+use crate::promql::MatrixSample;
+use crate::tsdb::{CounterCollection, Labels};
+
+mod irate;
+mod sum_by;
+
+#[cfg(test)]
+mod tests;
+
+pub use irate::CounterIrate;
+pub use sum_by::{sum_by, SumMerge};
+
+/// A single sample emitted through a streaming pipeline.
+///
+/// Timestamps are kept in raw nanoseconds — the same shape the TSDB
+/// stores. Conversion to seconds happens once, at the JSON boundary,
+/// to avoid the precision-loss round-trip the eager aggregator does
+/// (ns → f64 sec → u64 ns key).
+pub type Point = (u64, f64);
+
+/// A labeled, lazily-produced time series.
+///
+/// `iter` is type-erased so heterogeneous operator chains can sit in
+/// the same `Vec`. Once the API stabilises, the boxed form can be
+/// replaced with a generic `S: Iterator<Item = Point>` for monomorphised
+/// inlining; for the prototype, keeping things `dyn` keeps the surface
+/// area small while we validate the shape.
+pub struct LabeledSeries<'a> {
+    pub labels: Labels,
+    pub iter: Box<dyn Iterator<Item = Point> + 'a>,
+}
+
+impl<'a> LabeledSeries<'a> {
+    pub fn new<I>(labels: Labels, iter: I) -> Self
+    where
+        I: Iterator<Item = Point> + 'a,
+    {
+        Self {
+            labels,
+            iter: Box::new(iter),
+        }
+    }
+}
+
+/// Output of a streaming evaluation stage. Conceptually equivalent to
+/// `QueryResult::Matrix` but unmaterialised.
+pub type SeriesSet<'a> = Vec<LabeledSeries<'a>>;
+
+/// Build an iterator stream of `irate` over every counter series in
+/// `collection` whose labels match `filter`.
+///
+/// The iterators borrow the underlying counter sample slice — the
+/// caller must keep `collection` alive for the lifetime of the
+/// returned `SeriesSet`. This is the producer side of the pipeline:
+/// no values are computed until the consumer pulls.
+pub fn irate_counters<'a>(
+    collection: &'a CounterCollection,
+    filter: &Labels,
+    start_ns: u64,
+    end_ns: u64,
+    step_ns: u64,
+    range_ns: u64,
+) -> SeriesSet<'a> {
+    let mut out = Vec::new();
+    for (labels, series) in collection.iter() {
+        if !filter.inner.is_empty() && !labels.matches(filter) {
+            continue;
+        }
+        let iter = CounterIrate::new(series.samples(), start_ns, end_ns, step_ns, range_ns);
+        out.push(LabeledSeries::new(labels.clone(), iter));
+    }
+    out
+}
+
+/// Boundary collector: drain a streaming result into the same
+/// `MatrixSample` shape the eager engine returns, so the prototype can
+/// be plumbed through the existing JSON serializer unchanged.
+///
+/// Empty series (operators that never emitted) are dropped to match
+/// the eager path's behaviour.
+pub fn collect_to_matrix(streaming: SeriesSet<'_>, metric_name: &str) -> Vec<MatrixSample> {
+    streaming
+        .into_iter()
+        .filter_map(|ls| {
+            let values: Vec<(f64, f64)> = ls.iter.map(|(t, v)| (t as f64 / 1e9, v)).collect();
+            if values.is_empty() {
+                return None;
+            }
+            let mut metric: HashMap<String, String> = HashMap::new();
+            metric.insert("__name__".to_string(), metric_name.to_string());
+            for (k, v) in ls.labels.inner.iter() {
+                metric.insert(k.clone(), v.clone());
+            }
+            Some(MatrixSample { metric, values })
+        })
+        .collect()
+}

--- a/metriken-query/src/promql/streaming/sum_by.rs
+++ b/metriken-query/src/promql/streaming/sum_by.rs
@@ -1,0 +1,88 @@
+//! `sum by (labels)` as a streaming aggregator.
+//!
+//! Children are bucketed by their reduced label set up front; for each
+//! group we build a [`SumMerge`] iterator that pulls one point at a
+//! time from every child belonging to that group, summing values that
+//! share a timestamp.
+//!
+//! Aggregation is the model's main barrier: a group's emitted point at
+//! time `t` requires having peeked all children at `t`. State is one
+//! [`std::iter::Peekable`] per child — typically a single buffered
+//! `Point` (16 bytes) per series — so an aggregate over `S` children
+//! costs `O(S)` resident bytes regardless of stream length.
+//!
+//! The merge tolerates ragged inputs (children that skip timestamps);
+//! the smallest peeked timestamp wins each tick, and only children
+//! holding that exact timestamp contribute to the sum. Children with
+//! aligned grids (the common case for step-aligned PromQL queries)
+//! degenerate to a straight-line sum.
+
+use std::collections::HashMap;
+
+use crate::tsdb::Labels;
+
+use super::{LabeledSeries, Point, SeriesSet};
+
+/// Group `input` by the reduced label set selected via `by_labels`,
+/// then emit one [`LabeledSeries`] per group whose iterator sums all
+/// member iterators per timestamp.
+pub fn sum_by<'a>(input: SeriesSet<'a>, by_labels: &[String]) -> SeriesSet<'a> {
+    let mut groups: HashMap<Labels, Vec<Box<dyn Iterator<Item = Point> + 'a>>> = HashMap::new();
+    for ls in input {
+        let mut group_labels = Labels::default();
+        for k in by_labels {
+            if let Some(v) = ls.labels.inner.get(k) {
+                group_labels.inner.insert(k.clone(), v.clone());
+            }
+        }
+        groups.entry(group_labels).or_default().push(ls.iter);
+    }
+
+    groups
+        .into_iter()
+        .map(|(labels, children)| LabeledSeries::new(labels, SumMerge::new(children)))
+        .collect()
+}
+
+pub struct SumMerge<'a> {
+    children: Vec<std::iter::Peekable<Box<dyn Iterator<Item = Point> + 'a>>>,
+}
+
+impl<'a> SumMerge<'a> {
+    pub fn new(children: Vec<Box<dyn Iterator<Item = Point> + 'a>>) -> Self {
+        Self {
+            children: children.into_iter().map(Iterator::peekable).collect(),
+        }
+    }
+}
+
+impl<'a> Iterator for SumMerge<'a> {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Point> {
+        let mut min_ts: Option<u64> = None;
+        for c in self.children.iter_mut() {
+            if let Some(&(t, _)) = c.peek() {
+                min_ts = Some(min_ts.map_or(t, |m| m.min(t)));
+            }
+        }
+        let t = min_ts?;
+
+        let mut sum = 0.0;
+        let mut any = false;
+        for c in self.children.iter_mut() {
+            let take = matches!(c.peek(), Some(&(ts, _)) if ts == t);
+            if take {
+                let (_, v) = c.next().expect("peek returned Some, next must too");
+                sum += v;
+                any = true;
+            }
+        }
+
+        if any {
+            Some((t, sum))
+        } else {
+            None
+        }
+    }
+}

--- a/metriken-query/src/promql/streaming/tests.rs
+++ b/metriken-query/src/promql/streaming/tests.rs
@@ -97,10 +97,10 @@ fn streaming_irate_matches_eager_irate() {
     let stream = irate_counters(
         &collection,
         &Labels::default(),
-        1_000_000_000_000,                 // start_ns
-        1_003_000_000_000,                 // end_ns
-        1_000_000_000,                     // step_ns
-        5_000_000_000,                     // range_ns
+        1_000_000_000_000, // start_ns
+        1_003_000_000_000, // end_ns
+        1_000_000_000,     // step_ns
+        5_000_000_000,     // range_ns
     );
     let streaming = sort_by_name(collect_to_matrix(stream, "cgroup_cpu_usage"));
 
@@ -113,7 +113,12 @@ fn streaming_irate_matches_eager_irate() {
     );
     for (e, s) in eager.iter().zip(streaming.iter()) {
         assert_eq!(e.metric.get("name"), s.metric.get("name"));
-        assert_eq!(e.values.len(), s.values.len(), "point count for {:?}", e.metric.get("name"));
+        assert_eq!(
+            e.values.len(),
+            s.values.len(),
+            "point count for {:?}",
+            e.metric.get("name")
+        );
         for ((et, ev), (st, sv)) in e.values.iter().zip(s.values.iter()) {
             assert!((et - st).abs() < 1e-9, "ts mismatch: {et} vs {st}");
             assert!((ev - sv).abs() < 1e-9, "value mismatch: {ev} vs {sv}");
@@ -204,7 +209,13 @@ fn counter_irate_handles_reset() {
         (5_000_000_000, 150),
     ];
     // Range [5s], step 1s, evaluate at t=5s only.
-    let mut iter = CounterIrate::new(&samples, 5_000_000_000, 5_000_000_000, 1_000_000_000, 5_000_000_000);
+    let mut iter = CounterIrate::new(
+        &samples,
+        5_000_000_000,
+        5_000_000_000,
+        1_000_000_000,
+        5_000_000_000,
+    );
     let p = iter.next().expect("one point at t=5s");
     assert_eq!(p.0, 5_000_000_000);
     // Last two: (4s, 50) and (5s, 150). 150 >= 50 → delta=100/1s = 100.

--- a/metriken-query/src/promql/streaming/tests.rs
+++ b/metriken-query/src/promql/streaming/tests.rs
@@ -1,0 +1,213 @@
+//! Parity tests for the streaming prototype.
+//!
+//! Each streaming pipeline is run alongside an equivalent eager
+//! `query_range` invocation against the same TSDB; the results are
+//! sorted and compared pointwise. Any divergence — different number
+//! of series, missing labels, mismatched values — fails the test.
+//!
+//! These tests pin down the contract the rest of the engine must
+//! preserve when the migration proceeds operator-by-operator.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use metriken_exposition::{Counter, Snapshot, SnapshotV2};
+
+use crate::promql::streaming::{
+    collect_to_matrix, irate_counters, sum_by, CounterIrate, LabeledSeries,
+};
+use crate::promql::{MatrixSample, QueryEngine, QueryResult};
+use crate::tsdb::{Labels, Tsdb};
+
+/// Three counter series (foo/bar/baz) at t=1000..1002 with values
+/// (100,200,300) / (200,300,400) / (300,400,500). irate over a [5s]
+/// range yields 100/s at every emitted tick for every series.
+fn cgroup_tsdb() -> Tsdb {
+    let mut tsdb = Tsdb::default();
+    let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+    let cgroups = [
+        ("/system.slice/foo.service", 100u64),
+        ("/system.slice/bar.service", 200u64),
+        ("/system.slice/baz.service", 300u64),
+    ];
+
+    for step in 0u64..3 {
+        let time = base_time + Duration::from_secs(step);
+        let mut counters = Vec::new();
+        for (name, base_val) in &cgroups {
+            let mut metadata = HashMap::new();
+            metadata.insert("name".to_string(), name.to_string());
+            metadata.insert("metric".to_string(), "cgroup_cpu_usage".to_string());
+            counters.push(Counter {
+                name: "cgroup_cpu_usage".to_string(),
+                value: base_val + step * 100,
+                metadata,
+            });
+        }
+        let snapshot = Snapshot::V2(SnapshotV2 {
+            systemtime: time,
+            duration: Duration::from_secs(1),
+            metadata: HashMap::new(),
+            counters,
+            gauges: Vec::new(),
+            histograms: Vec::new(),
+        });
+        tsdb.ingest(snapshot);
+    }
+
+    tsdb
+}
+
+/// Sort matrix samples by their `name` label so unordered HashMap
+/// iteration on either side doesn't trip the comparison.
+fn sort_by_name(mut v: Vec<MatrixSample>) -> Vec<MatrixSample> {
+    v.sort_by(|a, b| {
+        a.metric
+            .get("name")
+            .cloned()
+            .unwrap_or_default()
+            .cmp(&b.metric.get("name").cloned().unwrap_or_default())
+    });
+    v
+}
+
+fn into_sorted(result: QueryResult) -> Vec<MatrixSample> {
+    match result {
+        QueryResult::Matrix { result } => sort_by_name(result),
+        other => panic!("expected matrix result, got {other:?}"),
+    }
+}
+
+#[test]
+fn streaming_irate_matches_eager_irate() {
+    let tsdb = Arc::new(cgroup_tsdb());
+
+    // Eager.
+    let engine = QueryEngine::new(tsdb.clone());
+    let eager = engine
+        .query_range("irate(cgroup_cpu_usage[5s])", 1000.0, 1003.0, 1.0)
+        .unwrap();
+    let eager = into_sorted(eager);
+
+    // Streaming.
+    let collection = tsdb
+        .counters("cgroup_cpu_usage", Labels::default())
+        .expect("collection present");
+    let stream = irate_counters(
+        &collection,
+        &Labels::default(),
+        1_000_000_000_000,                 // start_ns
+        1_003_000_000_000,                 // end_ns
+        1_000_000_000,                     // step_ns
+        5_000_000_000,                     // range_ns
+    );
+    let streaming = sort_by_name(collect_to_matrix(stream, "cgroup_cpu_usage"));
+
+    assert_eq!(
+        eager.len(),
+        streaming.len(),
+        "series count must match (eager={}, streaming={})",
+        eager.len(),
+        streaming.len()
+    );
+    for (e, s) in eager.iter().zip(streaming.iter()) {
+        assert_eq!(e.metric.get("name"), s.metric.get("name"));
+        assert_eq!(e.values.len(), s.values.len(), "point count for {:?}", e.metric.get("name"));
+        for ((et, ev), (st, sv)) in e.values.iter().zip(s.values.iter()) {
+            assert!((et - st).abs() < 1e-9, "ts mismatch: {et} vs {st}");
+            assert!((ev - sv).abs() < 1e-9, "value mismatch: {ev} vs {sv}");
+        }
+    }
+}
+
+#[test]
+fn streaming_sum_by_matches_eager_sum_by() {
+    let tsdb = Arc::new(cgroup_tsdb());
+
+    let engine = QueryEngine::new(tsdb.clone());
+    let eager = engine
+        .query_range(
+            "sum by (name) (irate(cgroup_cpu_usage[5s]))",
+            1000.0,
+            1003.0,
+            1.0,
+        )
+        .unwrap();
+    let eager = into_sorted(eager);
+
+    let collection = tsdb
+        .counters("cgroup_cpu_usage", Labels::default())
+        .expect("collection present");
+    let irate_stream = irate_counters(
+        &collection,
+        &Labels::default(),
+        1_000_000_000_000,
+        1_003_000_000_000,
+        1_000_000_000,
+        5_000_000_000,
+    );
+    let summed = sum_by(irate_stream, &["name".to_string()]);
+    let streaming = sort_by_name(collect_to_matrix(summed, "cgroup_cpu_usage"));
+
+    assert_eq!(eager.len(), streaming.len());
+    for (e, s) in eager.iter().zip(streaming.iter()) {
+        assert_eq!(e.metric.get("name"), s.metric.get("name"));
+        assert_eq!(e.values.len(), s.values.len());
+        for ((et, ev), (st, sv)) in e.values.iter().zip(s.values.iter()) {
+            assert!((et - st).abs() < 1e-9);
+            assert!((ev - sv).abs() < 1e-9);
+        }
+    }
+}
+
+#[test]
+fn sum_by_groups_disjoint_label_into_one_series() {
+    // Build two streams with different `name` labels; sum_by(["name"])
+    // keeps them apart; sum_by([]) folds them into a single group.
+    let mut a_labels = Labels::default();
+    a_labels.inner.insert("name".to_string(), "a".to_string());
+    let mut b_labels = Labels::default();
+    b_labels.inner.insert("name".to_string(), "b".to_string());
+
+    let a_pts: Vec<(u64, f64)> = vec![(1, 1.0), (2, 2.0), (3, 3.0)];
+    let b_pts: Vec<(u64, f64)> = vec![(1, 10.0), (2, 20.0), (3, 30.0)];
+
+    let stream = vec![
+        LabeledSeries::new(a_labels.clone(), a_pts.clone().into_iter()),
+        LabeledSeries::new(b_labels.clone(), b_pts.clone().into_iter()),
+    ];
+    let by_name = sum_by(stream, &["name".to_string()]);
+    assert_eq!(by_name.len(), 2, "name-group keeps a and b separate");
+
+    let stream = vec![
+        LabeledSeries::new(a_labels, a_pts.into_iter()),
+        LabeledSeries::new(b_labels, b_pts.into_iter()),
+    ];
+    let folded = sum_by(stream, &[]);
+    assert_eq!(folded.len(), 1, "empty by-list collapses into one group");
+    let mut iter = folded.into_iter().next().unwrap().iter;
+    assert_eq!(iter.next(), Some((1, 11.0)));
+    assert_eq!(iter.next(), Some((2, 22.0)));
+    assert_eq!(iter.next(), Some((3, 33.0)));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn counter_irate_handles_reset() {
+    // Counter goes 100, 200, 300, 50 (reset), 150 at t=1..5 sec.
+    let samples: Vec<(u64, u64)> = vec![
+        (1_000_000_000, 100),
+        (2_000_000_000, 200),
+        (3_000_000_000, 300),
+        (4_000_000_000, 50),
+        (5_000_000_000, 150),
+    ];
+    // Range [5s], step 1s, evaluate at t=5s only.
+    let mut iter = CounterIrate::new(&samples, 5_000_000_000, 5_000_000_000, 1_000_000_000, 5_000_000_000);
+    let p = iter.next().expect("one point at t=5s");
+    assert_eq!(p.0, 5_000_000_000);
+    // Last two: (4s, 50) and (5s, 150). 150 >= 50 → delta=100/1s = 100.
+    assert!((p.1 - 100.0).abs() < 1e-9);
+    assert!(iter.next().is_none());
+}

--- a/metriken-query/src/tsdb/series/counter.rs
+++ b/metriken-query/src/tsdb/series/counter.rs
@@ -37,6 +37,12 @@ impl CounterSeries {
         Some((first, last))
     }
 
+    /// Borrow the raw sample slice. Used by streaming operators that
+    /// build iterator pipelines without cloning.
+    pub(crate) fn samples(&self) -> &[(u64, u64)] {
+        &self.inner
+    }
+
     /// Slice covering all samples whose timestamp falls in `[start, end]`.
     fn range_window(&self, start: u64, end: u64) -> &[(u64, u64)] {
         let lo = self.inner.partition_point(|&(t, _)| t < start);


### PR DESCRIPTION
## Summary

Sketches a streaming time-series query model alongside the existing eager pipeline so we can validate the shape end-to-end before migrating the rest of the operators.

The eager engine materialises every intermediate stage as `Vec<(f64, f64)>`, so a typical `sum by (label) (irate(metric[5s]))` over many series produces a transient `O(stages × points × series)` heap footprint just to be reduced down to `O(stages × points)` at the boundary. That's painful in the WASM viewer where the heap is constrained.

This PR adds a new `promql::streaming` module that models a query as an iterator chain. Each operator pulls one `(t, v)` at a time and holds only its own windowed state; the boundary collector materialises into the existing `MatrixSample` shape so the JSON serializer stays untouched.

### What's wired up

- `Point = (u64, f64)` — the single sample type carried through the pipeline (raw ns, no precision-loss round trip).
- `LabeledSeries<'a>` — labelset + boxed iterator yielding `Point`. Type-erased so heterogeneous operator chains can sit in one `Vec`.
- `CounterIrate` — producer; `irate` over a borrowed counter sample slice.
- `SumMerge` / `sum_by` — aggregator; buckets children by reduced label set, then sums per timestamp tick using a peekable-merge across children.
- `irate_counters(...)` — convenience builder over a `CounterCollection`.
- `collect_to_matrix(...)` — boundary drain into the existing `MatrixSample` shape.

### What's intentionally NOT wired up

- `query_range` still uses the eager path. Migrating the rest of the operators (rate, histogram_quantile, binary ops, vector selector, etc.) is a follow-up; this PR pins down the model first.
- No CSE pass yet — duplicate sub-expressions in the same query would be re-evaluated by the streaming pipeline. PromQL queries from the rezolus dashboards almost never share sub-trees, so this is deferred.
- Heatmaps stay materialised; the result shape is inherently 2D.

### Verification

`cargo test -p metriken-query` — 45 tests pass (4 new). The new tests run streaming and eager pipelines against the same TSDB and compare pointwise:

- `streaming_irate_matches_eager_irate`
- `streaming_sum_by_matches_eager_sum_by`
- `sum_by_groups_disjoint_label_into_one_series`
- `counter_irate_handles_reset`

## Test plan

- [x] `cargo test -p metriken-query` passes
- [x] `cargo clippy -p metriken-query --all-targets` clean (only a pre-existing unknown-lint warning unrelated to this PR)
- [ ] Wire `query_range` to the streaming pipeline behind a feature flag (follow-up PR)
- [ ] Add streaming `rate` / `avg_over_time` / `histogram_percentiles` (follow-up PR)
- [ ] Measure WASM heap high-water mark on a representative rezolus capture before/after migration (follow-up PR)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CDj6jzjDMjt1u9c1YvhJv4)_