### PR TITLE
chore: bump metriken-query to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### metriken-query 0.10.0
+
+Breaking — collapses the PromQL evaluator to streaming-only and
+narrows the supported surface to the subset rezolus actually uses.
+
+- All eager evaluation removed. `evaluate_expr` now forwards every
+  expression to the streaming dispatcher; any AST shape the
+  dispatcher doesn't recognise becomes `QueryError::Unsupported`.
+- `histogram_heatmap` now streams its input — peak transient heap
+  drops ~54% per query versus the eager merge-then-walk path.
+- `histogram_quantile`, `histogram_quantiles`, counter `deriv`
+  (the 2nd-derivative case), gauge `deriv`, and the binary
+  operators (`+`, `-`, `*`, `/`) all flow through the streaming
+  pipeline.
+- The instant `query()` entry point now routes through
+  `query_range` with `start = end = time` and collapses the
+  resulting matrix to a vector by taking each series's latest
+  point. Inherits the full streaming PromQL surface.
+- Removed PromQL features (none used by the only known consumer):
+  `scalar(...)`, `vector(...)`, `group_left` / `group_right`
+  one-to-many binary matching, the matcher-less single-right
+  binary broadcast, and the eager `sum(scalar(x))` passthrough.
+- Removed crate features: `http` (along with the `axum` dep and
+  the `promql::routes` axum router that lived behind it).
+- Removed Tsdb / Collection / Series API surface that had no
+  remaining callers: `Tsdb::counters` / `gauges` / `histograms`
+  (cloning variants — use `*_ref` instead),
+  `CounterCollection::filter` / `rate` / `filtered_rate`,
+  `GaugeCollection::filter` / `filtered_sum`,
+  `HistogramCollection::filter` / `sum`,
+  `CounterSeries::rate` / `windowed_rate` / `windowed_irate`,
+  `GaugeSeries::untyped`,
+  `HistogramSeries::heatmap` / `percentiles` (the eager
+  multi-quantile walker; streaming pipeline replaces it),
+  `UntypedCollection`.
+- Cumulative cachecannon-bench peak transient heap across 43
+  representative queries: 12.82 MiB → 7.53 MiB (−41%).
+
 ### metriken-query 0.9.5
 
 - Store histograms in the TSDB as `CumulativeROHistogram`, which only retains

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.9.6"
+version = "0.10.0"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

Bumps `metriken-query` from `0.9.6` → `0.10.0`.

PR #94 collapsed the PromQL evaluator to streaming-only and removed substantial public API surface (`Tsdb::counters`/`gauges`/`histograms` cloning variants, several `Collection`/`Series` helpers, `UntypedCollection`, the `http` Cargo feature + axum router, several PromQL functions). The minor-version bump in `0.x` flags the breaking change for downstream callers per semver.

CHANGELOG entry summarises what was removed and the cachecannon-bench impact (peak heap −41% across 43 representative queries).

## Cross-repo coordination

[iopsystems/rezolus#856](https://github.com/iopsystems/rezolus/pull/856) is open with the matching `histogram_percentiles` → `histogram_quantiles` rename and the `http` feature-flag drop. Once `0.10.0` is published, that PR's metriken-query workspace pin can be bumped from `0.9.5` → `0.10.0` and it can land.

## Test plan

- [x] `cargo build -p metriken-query` clean (Cargo.lock regenerated for the new version)
- [x] `cargo test -p metriken-query` unchanged (45 tests pass — already verified in #94)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CDj6jzjDMjt1u9c1YvhJv4)_