### PR TITLE
chore: bump metriken-query to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### metriken-query 0.10.1
+
+- Cache the parquet footer once per load and decode columns one at a
+  time within each row group. Restores load performance on wide files
+  that regressed in 0.9.6's per-column projection rewrite — 5–28×
+  faster than 0.10.0 across the rezolus dashboard fixtures
+  (vllm.parquet 21.0s → 0.74s; sglang-nixl-16c 130s → 6.0s).
+
 ### metriken-query 0.10.0
 
 Breaking — collapses the PromQL evaluator to streaming-only and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
Patch release covering the parquet load-time fix from #96. Closes the load regression that 0.9.6 introduced; 5–28× faster than 0.10.0 across the rezolus dashboard fixtures.

## Load time (cold-warm-warm median of 3, ms)

| File              |  Cols | 0.9.5 | 0.9.6 / 0.10.0 | 0.10.1 |
|-------------------|------:|------:|---------------:|-------:|
| AB_base           |   961 |   281 |          4 795 |    596 |
| cachecannon       |  1228 |   230 |          6 571 |    656 |
| sglang_gemma3     |  1306 |   449 |          8 586 |    594 |
| vllm              |  2015 |   346 |         20 989 |    739 |
| sglang-nixl-16c   |  5028 | 5 119 |        130 000 |  6 015 |

0.9.6 and 0.10.0 share the same loader — the streaming refactor in 0.10.0 left the parquet path alone, so its load profile is identical to 0.9.6's.

## Resource / speed trade-offs across versions

| Axis                          | 0.9.5            | 0.9.6 / 0.10.0          | 0.10.1               |
|-------------------------------|------------------|-------------------------|----------------------|
| Load: small files (~1k cols)  | ~250 ms          | 5–9 s (regression)      | ~600 ms              |
| Load: wide files (≥2k cols)   | ~5 s nixl-16c    | 21–130 s (catastrophic) | ~0.7 s vllm, ~6 s nixl |
| Peak heap during load         | all cols of one row group | one column at a time | one column at a time |
| Peak heap per query (eager)   | high             | high (0.9.6)            | n/a                  |
| Peak heap per query (streaming) | n/a            | low (0.10.0)            | low                  |
| Histogram bucket storage      | u64 cumulative   | u32 per-period delta    | u32 per-period delta |

Key inflection points:

- **0.9.5 → 0.9.6** swapped histogram storage from u64 cumulative-since-start to u32 per-period delta (halves per-bucket width; queries no longer pay diff cost) and switched the loader to per-column projection (low peak resident, but re-parses the footer on every column — that's the regression). Net: better memory at every axis, but disastrous load speed on wide files.
- **0.9.6 → 0.10.0** collapsed the PromQL evaluator to streaming-only. Per-query peak heap drops sharply (e.g. `histogram_heatmap` 9.86 → 4.57 MiB, `histogram_quantiles` 2.63 MiB → 20 KiB per call, cumulative across 43 cachecannon-bench queries 12.82 → 7.53 MiB). Loader path unchanged, so the load regression carries through.
- **0.10.0 → 0.10.1** caches the parquet footer once via `ArrowReaderMetadata::load` and decodes columns one at a time within each row group. Restores load speed without giving up the low load-time peak.

0.10.1 is the first release that's good on every axis at once. Versus 0.9.5 it still loads slightly slower on small files because we now pay the per-period bucket-diff at load time — that's a deliberate query-time/load-time swap that the streaming pipeline depends on, and the load cost is bounded (delta = `curr - prev` once per histogram tick, never recomputed) while the query-side savings are paid every query.

## Speedup vs 0.10.0

| File              |  Cols | 0.10.0 | 0.10.1 | Speedup |
|-------------------|------:|-------:|-------:|--------:|
| AB_base           |   961 |  4.8 s | 0.60 s |    8.0× |
| cachecannon       |  1228 |  6.6 s | 0.66 s |   10.0× |
| sglang_gemma3     |  1306 |  8.6 s | 0.59 s |   14.5× |
| vllm              |  2015 | 21.0 s | 0.74 s |   28.4× |
| sglang-nixl-16c   |  5028 |  130 s |  6.0 s |   21.6× |