### PR TITLE
fix(query): restore matcher-less single-right binary broadcast (bump to 0.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### metriken-query 0.10.2
+
+- Restore the matcher-less single-right binary broadcast. Queries
+  shaped like `sum(rate(x[..])) / y` (where the aggregate strips
+  labels and `y` carries some) were silently empty in 0.10.0/0.10.1
+  on single-host parquets — the rezolus viewer's CPU-utilization
+  tiles relied on this fallback. Now `matrix_matrix_op` materialises
+  the lone unmatched right series into a shared timestamp lookup
+  and broadcasts it across every unmatched left series, mirroring
+  the eager engine's per-left fallback.
+
 ### metriken-query 0.10.1
 
 - Cache the parquet footer once per load and decode columns one at a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/promql/streaming/binary.rs
+++ b/metriken-query/src/promql/streaming/binary.rs
@@ -283,10 +283,7 @@ pub fn matrix_matrix_op<'a>(
     // unmatched right series, pair every unmatched left with that
     // singleton (timestamps via a shared lookup).  Mirrors the eager
     // engine's per-left fallback for `aggregated / scalar_metric`.
-    if !unmatched_left.is_empty()
-        && matches!(spec, MatchSpec::Default)
-        && right_by_key.len() == 1
-    {
+    if !unmatched_left.is_empty() && matches!(spec, MatchSpec::Default) && right_by_key.len() == 1 {
         let (_, right_singleton) = right_by_key.into_iter().next().unwrap();
         let rhs: Rc<HashMap<u64, f64>> = Rc::new(right_singleton.iter.collect());
         for left in unmatched_left {

--- a/metriken-query/src/promql/streaming/binary.rs
+++ b/metriken-query/src/promql/streaming/binary.rs
@@ -11,24 +11,25 @@
 //! * **Series-set joining** — [`matrix_matrix_op`] groups the right
 //!   side by label-match key (per [`MatchSpec`]) and pairs each
 //!   left-side series with its matching right-side series. Series
-//!   that don't find a match are dropped, matching the eager
-//!   engine's behaviour modulo the single-right fallback (see
-//!   below).
+//!   that don't find a match are dropped.
 //!
-//! What's NOT covered here and falls back to eager:
+//! When no `on()`/`ignoring()` modifier is given AND exactly one
+//! right-side series is left after the keyed join, that singleton is
+//! broadcast against every unmatched left series via
+//! [`RightLookupBinary`] (materialises the one right series's points
+//! into a shared timestamp lookup). Mirrors the eager engine's
+//! per-left-series fallback.
+//!
+//! What's NOT covered here:
 //!
 //! * `group_left` / `group_right` (one-to-many matching) — needs an
 //!   iterator-tee mechanism that defeats streaming.
-//! * Single-right fallback (`metric / scalar_aggregate` without an
-//!   `on()`/`ignoring()` modifier) — would require buffering one
-//!   side. The eager path keeps this working transparently; the
-//!   streaming dispatcher returns `None` so the eager evaluator
-//!   takes over.
 //! * Comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`) and
 //!   the `bool` modifier — not implemented in the eager engine
 //!   today either.
 
 use std::collections::{BTreeMap, HashMap};
+use std::rc::Rc;
 
 use promql_parser::parser::token::TokenType;
 
@@ -211,20 +212,46 @@ impl<'a> Iterator for ZipMergeBinary<'a> {
     }
 }
 
+/// Wrap a left-side `(t, v)` iterator and apply `op` against a
+/// pre-materialised right-side timestamp→value lookup.  Used by the
+/// single-right broadcast fallback in [`matrix_matrix_op`] — the same
+/// `Rc<HashMap<...>>` is shared across every left series, so the right
+/// singleton is decoded once regardless of left fan-out.
+pub struct RightLookupBinary<'a> {
+    upstream: Box<dyn Iterator<Item = Point> + 'a>,
+    op: BinOp,
+    rhs: Rc<HashMap<u64, f64>>,
+}
+
+impl<'a> Iterator for RightLookupBinary<'a> {
+    type Item = Point;
+
+    fn next(&mut self) -> Option<Point> {
+        for (t, lv) in self.upstream.by_ref() {
+            if let Some(&rv) = self.rhs.get(&t) {
+                if let Some(v) = self.op.apply(lv, rv) {
+                    return Some((t, v));
+                }
+            }
+        }
+        None
+    }
+}
+
 /// `left OP right` over two series sets, joining by `spec`-derived
 /// match key. Output preserves left's labels (matching the eager
 /// path, which copies `left_sample.metric.clone()` to the result).
 ///
-/// Returns `None` instead of an empty `SeriesSet` when the dispatcher
-/// would need the eager engine's single-right fallback (left has at
-/// least one series with no match on the right, AND `spec` is
-/// `Default`, AND right is single-series). Caller falls back to eager.
+/// When `spec` is `Default` and exactly one right-side series remains
+/// unmatched after the keyed join, that singleton is broadcast against
+/// every unmatched left series — common case is `sum(rate(x[..])) / y`
+/// where `sum(...)` strips labels and `y` carries some.
 pub fn matrix_matrix_op<'a>(
     left_set: SeriesSet<'a>,
     right_set: SeriesSet<'a>,
     op: BinOp,
     spec: MatchSpec<'_>,
-) -> Option<SeriesSet<'a>> {
+) -> SeriesSet<'a> {
     // Index right side by match key.  If two right-side series share
     // a key, the later one wins (the eager engine's HashMap-insert
     // has the same shape).
@@ -236,7 +263,7 @@ pub fn matrix_matrix_op<'a>(
     }
 
     let mut out: SeriesSet<'a> = Vec::new();
-    let mut any_unmatched = false;
+    let mut unmatched_left: Vec<LabeledSeries<'a>> = Vec::new();
     for left in left_set {
         let lk = match_key(&left.labels, spec);
         match right_by_key.remove(&lk) {
@@ -248,28 +275,29 @@ pub fn matrix_matrix_op<'a>(
                 };
                 out.push(LabeledSeries::new(left.labels, iter));
             }
-            None => {
-                // Drop this left series — it doesn't match anything
-                // on the right.  Track for the fallback decision
-                // below.
-                any_unmatched = true;
-                drop(left);
-            }
+            None => unmatched_left.push(left),
         }
     }
 
-    // Single-right fallback: when no explicit matcher is given AND
-    // left had unmatched series AND right was single-series, the
-    // eager engine pairs every left with that one right. We can't
-    // tee a streaming iterator without buffering, so signal "fall
-    // back to eager" rather than silently dropping series.
-    let needs_fallback = any_unmatched
+    // Single-right broadcast: with no explicit matcher and exactly one
+    // unmatched right series, pair every unmatched left with that
+    // singleton (timestamps via a shared lookup).  Mirrors the eager
+    // engine's per-left fallback for `aggregated / scalar_metric`.
+    if !unmatched_left.is_empty()
         && matches!(spec, MatchSpec::Default)
         && right_by_key.len() == 1
-        && out.is_empty();
-    if needs_fallback {
-        return None;
+    {
+        let (_, right_singleton) = right_by_key.into_iter().next().unwrap();
+        let rhs: Rc<HashMap<u64, f64>> = Rc::new(right_singleton.iter.collect());
+        for left in unmatched_left {
+            let iter = RightLookupBinary {
+                upstream: left.iter,
+                op,
+                rhs: Rc::clone(&rhs),
+            };
+            out.push(LabeledSeries::new(left.labels, iter));
+        }
     }
 
-    Some(out)
+    out
 }

--- a/metriken-query/src/promql/streaming/dispatch.rs
+++ b/metriken-query/src/promql/streaming/dispatch.rs
@@ -17,8 +17,9 @@
 //! * `lhs OP rhs` where OP ∈ {`+`, `-`, `*`, `/`} — binary ops
 //!   between two series sets or between a series set and a number
 //!   literal. Honors `on(..)` and `ignoring(..)` matching modifiers.
-//!   `group_left` / `group_right` and the matcher-less single-right
-//!   broadcast are NOT supported (errors with `Unsupported`).
+//!   With no modifier, an unmatched left set is broadcast against a
+//!   single unmatched right series (eager-engine parity). `group_left`
+//!   / `group_right` are NOT supported.
 //! * `NumberLiteral` — produces a `Built::Scalar`; usable on either
 //!   side of a binary op.
 //! * Parenthesised expressions are unwrapped.
@@ -232,21 +233,11 @@ where
                 series: right_series,
                 ..
             },
-        ) => {
-            let Some(joined) = matrix_matrix_op(left_series, right_series, op, spec) else {
-                return Err(QueryError::Unsupported(
-                    "matrix×matrix without an `on(..)` / `ignoring(..)` modifier requires \
-                     compatible label sets; the matcher-less single-right broadcast is not \
-                     supported"
-                        .to_string(),
-                ));
-            };
-            Ok(Built::Series {
-                series: joined,
-                metric_name: None,
-                metric_name_for_error: None,
-            })
-        }
+        ) => Ok(Built::Series {
+            series: matrix_matrix_op(left_series, right_series, op, spec),
+            metric_name: None,
+            metric_name_for_error: None,
+        }),
         (Built::Scalar(a), Built::Scalar(b)) => {
             Ok(Built::Scalar(op.apply(a, b).unwrap_or(f64::NAN)))
         }

--- a/metriken-query/src/promql/streaming/tests.rs
+++ b/metriken-query/src/promql/streaming/tests.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use metriken_exposition::{Counter, Snapshot, SnapshotV2};
+use metriken_exposition::{Counter, Gauge, Snapshot, SnapshotV2};
 
 use crate::promql::streaming::{
     collect_to_matrix, irate_counters, sum_by, CounterIrate, LabeledSeries,
@@ -226,6 +226,63 @@ fn counter_irate_handles_reset() {
     // Last two: (4s, 50) and (5s, 150). 150 >= 50 → delta=100/1s = 100.
     assert!((p.1 - 100.0).abs() < 1e-9);
     assert!(iter.next().is_none());
+}
+
+/// Models the rezolus viewer's CPU-utilization pattern:
+/// `sum(irate(cpu_usage[5s])) / cpu_cores`. The aggregator strips
+/// labels from the LHS, so default-matching against `cpu_cores`
+/// (which carries `node`, `source`) finds nothing — without the
+/// single-right broadcast the query returns empty and the viewer
+/// shows no data.
+#[test]
+fn single_right_broadcasts_against_label_stripping_aggregate() {
+    let mut tsdb = Tsdb::default();
+    let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+
+    // Two cpu_usage counter series at different cpus, each ramping
+    // 100/s. sum(irate(...)) over both = 200/s.
+    for step in 0u64..3 {
+        let mut counters = Vec::new();
+        for cpu in 0..2u64 {
+            let mut md = HashMap::new();
+            md.insert("metric".to_string(), "cpu_usage".to_string());
+            md.insert("cpu".to_string(), cpu.to_string());
+            counters.push(Counter {
+                name: "cpu_usage".to_string(),
+                value: cpu * 1000 + step * 100,
+                metadata: md,
+            });
+        }
+        let mut node_md = HashMap::new();
+        node_md.insert("metric".to_string(), "cpu_cores".to_string());
+        node_md.insert("node".to_string(), "agent-0".to_string());
+        node_md.insert("source".to_string(), "rezolus".to_string());
+        let gauges = vec![Gauge {
+            name: "cpu_cores".to_string(),
+            value: 4,
+            metadata: node_md,
+        }];
+
+        tsdb.ingest(Snapshot::V2(SnapshotV2 {
+            systemtime: base + Duration::from_secs(step),
+            duration: Duration::from_secs(1),
+            metadata: HashMap::new(),
+            counters,
+            gauges,
+            histograms: Vec::new(),
+        }));
+    }
+
+    let engine = QueryEngine::new(Arc::new(tsdb));
+    let q = "sum(irate(cpu_usage[5s])) / cpu_cores";
+    let r = engine.query(q, None).expect("query must succeed");
+    let samples = match r {
+        QueryResult::Vector { result } => result,
+        other => panic!("expected vector result, got {other:?}"),
+    };
+    assert_eq!(samples.len(), 1, "expected one broadcast series");
+    // sum(irate) = 200 c/s across both cpus; / cpu_cores (=4) = 50.
+    assert!((samples[0].value.1 - 50.0).abs() < 1e-9, "got {samples:?}");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a silent regression introduced in 0.10.0: queries shaped like `sum(rate(x[..])) / y` returned empty on single-host parquets, blanking out the rezolus viewer's CPU-utilization tiles (`sum(irate(cpu_usage[5m])) / cpu_cores / 1e9` and friends).

## Root cause

`sum(...)` strips labels from the LHS. `cpu_cores` carries `node` / `source`. Default-matching binary ops require label sets to align — they didn't. The eager engine had a per-left fallback: when no `on()` / `ignoring()` modifier and exactly one right series remains, broadcast that singleton against every unmatched left. The 0.10.0 cleanup deleted that path on the assumption rezolus didn't use it; the viewer code path actually does.

## Fix

`matrix_matrix_op` now performs the keyed join, then if any left series remains unmatched and exactly one right series remains unmatched (default matching), it materialises the right singleton's points into an `Rc<HashMap<u64, f64>>` and broadcasts it across the unmatched left set via a new `RightLookupBinary` iterator. The shared `Rc` decodes the right side once regardless of left fan-out.

Multi-host case (RHS > 1 with default matching) still returns empty — that's standard PromQL behaviour, matching the eager engine.

`matrix_matrix_op`'s vestigial `Option` return is dropped (it always returns `Some` now), as is the `Unsupported("matcher-less single-right broadcast is not supported")` branch in the dispatcher.

## Verification

Reproduced on three real parquet fixtures before/after the fix:

| Fixture          | RHS series | `sum(irate(cpu_usage[5m])) / cpu_cores` 0.10.1 | 0.10.2 |
|------------------|-----------:|-----------------------------------------------|--------|
| AB_base          |          1 | `Unsupported(...)`                            | OK     |
| sglang_gemma3    |          1 | `Unsupported(...)`                            | OK     |
| cachecannon      |          2 | empty                                         | empty  |

Plus a new unit test (`single_right_broadcasts_against_label_stripping_aggregate`) that builds a tiny in-memory TSDB and asserts the broadcast value.

Bumps metriken-query to 0.10.2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDj6jzjDMjt1u9c1YvhJv4)_