### PR TITLE
chore: bump metriken-query to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

Patch bump from 0.10.3 → 0.10.4 to cut a release that includes `QueryEngine::columns()` (added in #101).

The change is purely additive — a new method on the public API, plus a unified column-name map and `Tsdb::column()` accessor. No behavioral changes to existing query paths.

## Test plan

- [x] `cargo build -p metriken-query` succeeds with the new version
- [x] `Cargo.lock` regenerated via `cargo update -p metriken-query`

https://claude.ai/code/session_01HnYtm4hCJeMai1AjogjSwL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnYtm4hCJeMai1AjogjSwL)_