### PR TITLE
chore: bump metriken-query to 0.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",


### PR DESCRIPTION
## Summary

Patch bump for the next crate release. Picks up everything merged since 0.10.4:

- `feat(query): add histogram_mean / histogram_count PromQL functions` (#103) — two scalar histogram reducers plus a workspace bump to `histogram = "1.4.1"` so the streaming `mean` reducer can read `CumulativeROHistogram32Ref::mean()` as a cached field.

Following PR #102's pattern (version-only bump). Changelog entries for `0.10.3` / `0.10.4` / `0.10.5` weren't filled in by their respective chore PRs either — happy to add them in a follow-up if you'd like.

https://claude.ai/code/session_01AonYVpvAhrxg795LUYKVmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AonYVpvAhrxg795LUYKVmw)_