### PR TITLE
feat(query): histogram_irate + by/without grouping for histogram reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### metriken-query 0.10.6
+
+- Add `histogram_irate(m)` — per-step rate of a histogram's
+  cumulative sample count, returned as a single-series instant
+  vector labeled `{__name__: metric_name}`. Lets dashboards derive
+  a fallback event-rate line for histograms that have no
+  standalone counter (`scheduler_runqueue_latency`,
+  `scheduler_offcpu`, `scheduler_running`, `tcp_packet_latency`).
+  Composes with `sum(...)`, `sum by (..)(...)`, and
+  `sum without (..)(...)` directly. Replaces the
+  `sum(irate(histogram_count(m)[5m]))` idiom suggested for
+  `histogram_count` in 0.10.5, which never parsed — PromQL
+  disallows range vectors on function-call results.
+
 ### metriken-query 0.10.2
 
 - Restore the matcher-less single-right binary broadcast. Queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### metriken-query 0.10.6
 
 - Add `histogram_irate(m)` — per-step rate of a histogram's
-  cumulative sample count, returned as a single-series instant
-  vector labeled `{__name__: metric_name}`. Lets dashboards derive
-  a fallback event-rate line for histograms that have no
-  standalone counter (`scheduler_runqueue_latency`,
+  cumulative sample count, returned as an instant vector. Lets
+  dashboards derive a fallback event-rate line for histograms
+  that have no standalone counter (`scheduler_runqueue_latency`,
   `scheduler_offcpu`, `scheduler_running`, `tcp_packet_latency`).
-  Composes with `sum(...)`, `sum by (..)(...)`, and
-  `sum without (..)(...)` directly. Replaces the
-  `sum(irate(histogram_count(m)[5m]))` idiom suggested for
-  `histogram_count` in 0.10.5, which never parsed — PromQL
-  disallows range vectors on function-call results.
+  Replaces the `sum(irate(histogram_count(m)[5m]))` idiom
+  suggested for `histogram_count` in 0.10.5, which never parsed —
+  PromQL disallows range vectors on function-call results.
+- Add an optional `by (..)` / `without (..)` aggregation modifier
+  to `histogram_irate`, `histogram_count`, and `histogram_mean`,
+  matching standard PromQL aggregation-operator syntax. With no
+  modifier, every matching series collapses into one
+  `{__name__: metric_name}` output (today's behaviour); with
+  `by`/`without`, one series per distinct projected-label tuple.
+  Lets `histogram_mean by (source) (m)` return one mean per
+  source in a single query — previously required N filtered
+  queries.
 
 ### metriken-query 0.10.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/promql/columns.rs
+++ b/metriken-query/src/promql/columns.rs
@@ -74,9 +74,6 @@ fn strip_rezolus_wrapper(query: &str) -> Result<&str, QueryError> {
         let (selector, _stride) = parse_optional_stride(inner.trim())?;
         return Ok(selector);
     }
-    // The scalar reducers accept an optional `[by/without (..)]` clause
-    // before the body; defer to the shared parser so the column scan
-    // sees the same surface syntax `query_range` does.
     for func in ["histogram_mean", "histogram_count", "histogram_irate"] {
         if let Some((inner, _group_by)) = parse_histogram_call(func, query)? {
             let (selector, _stride) = parse_optional_stride(inner.trim())?;

--- a/metriken-query/src/promql/columns.rs
+++ b/metriken-query/src/promql/columns.rs
@@ -44,9 +44,10 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
 /// so the standard PromQL parser can handle it. The wrappers
 /// (`histogram_quantiles([qs], m, [stride])`, `histogram_heatmap(m,
 /// [stride])`, `histogram_mean(m, [stride])`, `histogram_count(m,
-/// [stride])`) use array-literal / multi-arg syntax the parser
-/// rejects, but their *column set* is just the inner selector's.
-/// Non-rezolus queries pass through unchanged.
+/// [stride])`, `histogram_irate(m)`) use array-literal / multi-arg
+/// syntax or names the parser doesn't recognise, but their *column
+/// set* is just the inner selector's. Non-rezolus queries pass
+/// through unchanged.
 fn strip_rezolus_wrapper(query: &str) -> Result<&str, QueryError> {
     if let Some(inner) = query
         .strip_prefix("histogram_quantiles(")
@@ -67,7 +68,12 @@ fn strip_rezolus_wrapper(query: &str) -> Result<&str, QueryError> {
         let (selector, _stride) = parse_optional_stride(remaining)?;
         return Ok(selector);
     }
-    for prefix in ["histogram_heatmap(", "histogram_mean(", "histogram_count("] {
+    for prefix in [
+        "histogram_heatmap(",
+        "histogram_mean(",
+        "histogram_count(",
+        "histogram_irate(",
+    ] {
         if let Some(inner) = query.strip_prefix(prefix).and_then(|s| s.strip_suffix(')')) {
             let (selector, _stride) = parse_optional_stride(inner.trim())?;
             return Ok(selector);

--- a/metriken-query/src/promql/columns.rs
+++ b/metriken-query/src/promql/columns.rs
@@ -13,7 +13,9 @@ use std::ops::Deref;
 use promql_parser::label::Matcher;
 use promql_parser::parser::{self, Expr};
 
-use crate::promql::{extract_filter_labels, parse_optional_stride, QueryEngine, QueryError};
+use crate::promql::{
+    extract_filter_labels, parse_histogram_call, parse_optional_stride, QueryEngine, QueryError,
+};
 use crate::tsdb::Tsdb;
 
 impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
@@ -65,13 +67,18 @@ fn strip_rezolus_wrapper(query: &str) -> Result<&str, QueryError> {
         let (selector, _stride) = parse_optional_stride(remaining)?;
         return Ok(selector);
     }
-    for prefix in [
-        "histogram_heatmap(",
-        "histogram_mean(",
-        "histogram_count(",
-        "histogram_irate(",
-    ] {
-        if let Some(inner) = query.strip_prefix(prefix).and_then(|s| s.strip_suffix(')')) {
+    if let Some(inner) = query
+        .strip_prefix("histogram_heatmap(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        let (selector, _stride) = parse_optional_stride(inner.trim())?;
+        return Ok(selector);
+    }
+    // The scalar reducers accept an optional `[by/without (..)]` clause
+    // before the body; defer to the shared parser so the column scan
+    // sees the same surface syntax `query_range` does.
+    for func in ["histogram_mean", "histogram_count", "histogram_irate"] {
+        if let Some((inner, _group_by)) = parse_histogram_call(func, query)? {
             let (selector, _stride) = parse_optional_stride(inner.trim())?;
             return Ok(selector);
         }

--- a/metriken-query/src/promql/columns.rs
+++ b/metriken-query/src/promql/columns.rs
@@ -40,14 +40,11 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
     }
 }
 
-/// Reduce a rezolus-specific wrapper to its inner metric selector
-/// so the standard PromQL parser can handle it. The wrappers
-/// (`histogram_quantiles([qs], m, [stride])`, `histogram_heatmap(m,
-/// [stride])`, `histogram_mean(m, [stride])`, `histogram_count(m,
-/// [stride])`, `histogram_irate(m)`) use array-literal / multi-arg
-/// syntax or names the parser doesn't recognise, but their *column
-/// set* is just the inner selector's. Non-rezolus queries pass
-/// through unchanged.
+/// Reduce a rezolus-specific wrapper to its inner metric selector so
+/// the standard PromQL parser can handle it. The wrappers use array
+/// literals, multi-arg shapes, or names the parser doesn't recognise,
+/// but their *column set* is just the inner selector's. Non-rezolus
+/// queries pass through unchanged.
 fn strip_rezolus_wrapper(query: &str) -> Result<&str, QueryError> {
     if let Some(inner) = query
         .strip_prefix("histogram_quantiles(")

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -123,21 +123,14 @@ fn split_last_top_level_comma(s: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// If `query` is `sum(histogram_irate(...))`, `sum by (..)(histogram_irate(...))`,
-/// or `sum without (..)(histogram_irate(...))`, return the inner
-/// `histogram_irate(...)` call. Otherwise return `None`.
-///
-/// `histogram_irate` already collapses every input series into one
-/// `{__name__: metric_name}` output, so any outer `sum`/`sum by`/
-/// `sum without` over it is functionally a no-op and the dashboard
-/// idiom `sum(histogram_irate(m))` (written for symmetry with
-/// `sum(irate(counter[5m]))`) reduces to the inner call.
+/// Strip an outer `sum(...)` / `sum by (..)(...)` / `sum without (..)(...)`
+/// wrapper if the inner call is `histogram_irate(...)`. The wrapper is a
+/// no-op since `histogram_irate` already collapses to one series; this lets
+/// `sum(histogram_irate(m))` parse even though promql-parser doesn't know
+/// the function name.
 fn strip_outer_sum_around_histogram_irate(query: &str) -> Option<&str> {
-    let q = query.trim();
-    let rest = q.strip_prefix("sum")?;
-    let rest = rest.trim_start();
+    let rest = query.trim().strip_prefix("sum")?.trim_start();
 
-    // Optional `by (labels)` / `without (labels)` modifier.
     let body = if let Some(r) = rest.strip_prefix("by") {
         let r = r.trim_start().strip_prefix('(')?;
         let close = find_top_level_close_paren(r)?;
@@ -163,9 +156,8 @@ fn strip_outer_sum_around_histogram_irate(query: &str) -> Option<&str> {
     }
 }
 
-/// Find the byte offset of the `)` that closes the open paren whose
-/// content begins at position 0 of `s` (i.e. depth starts at 1).
-/// Returns `None` if unbalanced.
+/// Find the `)` that closes the open paren whose content starts at byte 0
+/// of `s` (depth begins at 1). `None` if unbalanced.
 fn find_top_level_close_paren(s: &str) -> Option<usize> {
     let mut depth: usize = 1;
     for (i, ch) in s.char_indices() {
@@ -464,13 +456,9 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         }
     }
 
-    /// Handle `histogram_irate(metric{matchers})` queries.
-    ///
-    /// Per-step rate of the histogram's cumulative sample count, as a
-    /// single-series instant vector. Same metric-selector pre-parser
-    /// shape as `histogram_count` / `histogram_mean`, but no
-    /// window/stride argument — see `streaming::histogram::irate` for
-    /// the rationale.
+    /// Handle `histogram_irate(metric{matchers})`. Same metric-selector
+    /// shape as `histogram_count` / `histogram_mean`, but rejects a
+    /// trailing stride — see [`streaming::histogram::irate`].
     fn handle_histogram_irate(
         &self,
         query_str: &str,
@@ -581,14 +569,9 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             return self.handle_histogram_scalar("histogram_count", query_str, start, end);
         }
 
-        // `histogram_irate` is a rezolus extension — promql-parser
-        // doesn't know the name, so a nested form like
-        // `sum(histogram_irate(m))` never reaches the dispatcher.
-        // Since `histogram_irate` already collapses every matching
-        // series into a single output, the outer `sum(...)` (or
-        // `sum by (..)(...)` / `sum without (..)(...)`) wrapper is
-        // functionally a no-op; strip it here so the idiomatic
-        // dashboard form parses.
+        // promql-parser doesn't know `histogram_irate`, so peel a
+        // no-op outer `sum`/`sum by`/`sum without` wrapper here so
+        // the dashboard idiom `sum(histogram_irate(m))` parses.
         let effective = strip_outer_sum_around_histogram_irate(query_str).unwrap_or(query_str);
         if effective.starts_with("histogram_irate(") && effective.ends_with(")") {
             return self.handle_histogram_irate(effective, start, end);

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -123,9 +123,8 @@ fn split_last_top_level_comma(s: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// Owned grouping spec for the rezolus histogram reducers, parsed
-/// from `by (..)` / `without (..)` modifiers in `query_range`.
-/// Borrowed as a `streaming::GroupBy<'_>` at call sites.
+/// Owned counterpart to `streaming::GroupBy<'_>` — held on the
+/// handler stack between parse and dispatch, then borrowed.
 #[derive(Debug, Default, Clone)]
 pub(crate) enum HistogramGroupBy {
     #[default]
@@ -144,10 +143,8 @@ impl HistogramGroupBy {
     }
 }
 
-/// Parse a rezolus histogram call of shape
-/// `<func> [by (labels) | without (labels)] (...body...)` and return
-/// the inner body (without the outer parens) plus the grouping.
-/// Returns `Ok(None)` if `query` doesn't start with `<func>`.
+/// Parse `<func> [by (labels) | without (labels)] (body)`. `Ok(None)`
+/// if the prefix doesn't match.
 pub(crate) fn parse_histogram_call<'a>(
     func: &str,
     query: &'a str,
@@ -155,40 +152,18 @@ pub(crate) fn parse_histogram_call<'a>(
     let Some(after_name) = query.strip_prefix(func) else {
         return Ok(None);
     };
-    // Reject prefix matches against longer function names (e.g. don't
-    // let "histogram_count_extra(" match func="histogram_count").
-    let next = after_name.chars().next();
-    if !matches!(next, Some('(') | Some(' ') | Some('\t')) {
+    // Guard against prefix collisions with longer function names.
+    if !matches!(after_name.chars().next(), Some('(' | ' ' | '\t')) {
         return Ok(None);
     }
     let rest = after_name.trim_start();
 
     let (group_by, after_modifier) = if let Some(r) = rest.strip_prefix("by") {
-        let r = r.trim_start();
-        let inside = r
-            .strip_prefix('(')
-            .ok_or_else(|| QueryError::ParseError(format!("{func}: expected '(' after 'by'")))?;
-        let close = find_close_paren(inside).ok_or_else(|| {
-            QueryError::ParseError(format!("{func}: unbalanced parens in 'by' clause"))
-        })?;
-        let labels = parse_label_list(&inside[..close])?;
-        (
-            HistogramGroupBy::By(labels),
-            inside[close + 1..].trim_start(),
-        )
+        let (labels, after) = parse_grouping_clause(func, r.trim_start(), "by")?;
+        (HistogramGroupBy::By(labels), after)
     } else if let Some(r) = rest.strip_prefix("without") {
-        let r = r.trim_start();
-        let inside = r.strip_prefix('(').ok_or_else(|| {
-            QueryError::ParseError(format!("{func}: expected '(' after 'without'"))
-        })?;
-        let close = find_close_paren(inside).ok_or_else(|| {
-            QueryError::ParseError(format!("{func}: unbalanced parens in 'without' clause"))
-        })?;
-        let labels = parse_label_list(&inside[..close])?;
-        (
-            HistogramGroupBy::Without(labels),
-            inside[close + 1..].trim_start(),
-        )
+        let (labels, after) = parse_grouping_clause(func, r.trim_start(), "without")?;
+        (HistogramGroupBy::Without(labels), after)
     } else {
         (HistogramGroupBy::None, rest)
     };
@@ -201,12 +176,24 @@ pub(crate) fn parse_histogram_call<'a>(
             "{func}: missing closing ')'"
         )));
     }
-    let inner = &body[..body.len() - 1];
-    Ok(Some((inner, group_by)))
+    Ok(Some((&body[..body.len() - 1], group_by)))
 }
 
-/// Parse a comma-separated list of label identifiers. Empty entries
-/// are skipped (`by ()` is allowed, meaning "no labels").
+fn parse_grouping_clause<'a>(
+    func: &str,
+    s: &'a str,
+    keyword: &str,
+) -> Result<(Vec<String>, &'a str), QueryError> {
+    let inside = s
+        .strip_prefix('(')
+        .ok_or_else(|| QueryError::ParseError(format!("{func}: expected '(' after '{keyword}'")))?;
+    let close = find_close_paren(inside).ok_or_else(|| {
+        QueryError::ParseError(format!("{func}: unbalanced parens in '{keyword}' clause"))
+    })?;
+    let labels = parse_label_list(&inside[..close])?;
+    Ok((labels, inside[close + 1..].trim_start()))
+}
+
 fn parse_label_list(s: &str) -> Result<Vec<String>, QueryError> {
     let mut out = Vec::new();
     for part in s.split(',') {
@@ -224,8 +211,6 @@ fn parse_label_list(s: &str) -> Result<Vec<String>, QueryError> {
     Ok(out)
 }
 
-/// Find the `)` that closes the open paren whose content starts at
-/// byte 0 of `s` (depth begins at 1). `None` if unbalanced.
 fn find_close_paren(s: &str) -> Option<usize> {
     let mut depth: usize = 1;
     for (i, ch) in s.char_indices() {
@@ -524,9 +509,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         }
     }
 
-    /// Handle `histogram_irate(metric{matchers}) [by/without (..)]`.
-    /// Same shape as `histogram_count` / `histogram_mean`, but rejects
-    /// a trailing stride — see [`streaming::histogram::irate`].
+    /// Rejects a trailing stride — see [`streaming::histogram::irate`].
     fn handle_histogram_irate(
         &self,
         inner: &str,
@@ -564,11 +547,6 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         Ok(QueryResult::Matrix { result })
     }
 
-    /// Handle `histogram_mean(metric{matchers}[, stride]) [by/without (..)]`
-    /// and `histogram_count(metric{matchers}[, stride]) [by/without (..)]`.
-    /// With no grouping, every matching series collapses into one
-    /// `{__name__: metric_name}` output; with `by`/`without`, one series
-    /// per distinct projected-label tuple.
     fn handle_histogram_scalar(
         &self,
         func: &str,
@@ -633,10 +611,6 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             return self.handle_histogram_heatmap(query_str, start, end);
         }
 
-        // Scalar histogram reducers (rezolus extensions). Each accepts
-        // an optional aggregation-modifier clause `[by/without (..)]`
-        // between the function name and the metric body, mirroring the
-        // PromQL aggregation-operator syntax.
         for func in ["histogram_mean", "histogram_count"] {
             if let Some((inner, group_by)) = parse_histogram_call(func, query_str)? {
                 return self.handle_histogram_scalar(func, inner, group_by, start, end);

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -123,6 +123,66 @@ fn split_last_top_level_comma(s: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// If `query` is `sum(histogram_irate(...))`, `sum by (..)(histogram_irate(...))`,
+/// or `sum without (..)(histogram_irate(...))`, return the inner
+/// `histogram_irate(...)` call. Otherwise return `None`.
+///
+/// `histogram_irate` already collapses every input series into one
+/// `{__name__: metric_name}` output, so any outer `sum`/`sum by`/
+/// `sum without` over it is functionally a no-op and the dashboard
+/// idiom `sum(histogram_irate(m))` (written for symmetry with
+/// `sum(irate(counter[5m]))`) reduces to the inner call.
+fn strip_outer_sum_around_histogram_irate(query: &str) -> Option<&str> {
+    let q = query.trim();
+    let rest = q.strip_prefix("sum")?;
+    let rest = rest.trim_start();
+
+    // Optional `by (labels)` / `without (labels)` modifier.
+    let body = if let Some(r) = rest.strip_prefix("by") {
+        let r = r.trim_start().strip_prefix('(')?;
+        let close = find_top_level_close_paren(r)?;
+        r[close + 1..].trim_start()
+    } else if let Some(r) = rest.strip_prefix("without") {
+        let r = r.trim_start().strip_prefix('(')?;
+        let close = find_top_level_close_paren(r)?;
+        r[close + 1..].trim_start()
+    } else {
+        rest
+    };
+
+    let body = body.strip_prefix('(')?;
+    let close = find_top_level_close_paren(body)?;
+    if close != body.len() - 1 {
+        return None;
+    }
+    let inner = body[..close].trim();
+    if inner.starts_with("histogram_irate(") && inner.ends_with(')') {
+        Some(inner)
+    } else {
+        None
+    }
+}
+
+/// Find the byte offset of the `)` that closes the open paren whose
+/// content begins at position 0 of `s` (i.e. depth starts at 1).
+/// Returns `None` if unbalanced.
+fn find_top_level_close_paren(s: &str) -> Option<usize> {
+    let mut depth: usize = 1;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Collapse a matrix result into a vector by taking the latest
 /// point of each series. Used by `query()` to convert a degenerate
 /// range query (`start = end = time`) into instant-query shape.
@@ -404,6 +464,44 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         }
     }
 
+    /// Handle `histogram_irate(metric{matchers})` queries.
+    ///
+    /// Per-step rate of the histogram's cumulative sample count, as a
+    /// single-series instant vector. Same metric-selector pre-parser
+    /// shape as `histogram_count` / `histogram_mean`, but no
+    /// window/stride argument — see `streaming::histogram::irate` for
+    /// the rationale.
+    fn handle_histogram_irate(
+        &self,
+        query_str: &str,
+        start: f64,
+        end: f64,
+    ) -> Result<QueryResult, QueryError> {
+        let inner = &query_str["histogram_irate(".len()..query_str.len() - 1];
+        let (metric_selector, stride_ns) = parse_optional_stride(inner.trim())?;
+        if stride_ns.is_some() {
+            return Err(QueryError::ParseError(
+                "histogram_irate does not accept a window/stride argument".to_string(),
+            ));
+        }
+        let (metric_name, labels) = self.parse_metric_selector(metric_selector)?;
+
+        let Some(collection) = self.tsdb.histograms_ref(&metric_name) else {
+            return Err(QueryError::MetricNotFound(metric_name.to_string()));
+        };
+
+        let start_ns = (start * 1e9) as u64;
+        let end_ns = (end * 1e9) as u64;
+        let result =
+            streaming::histogram::irate(collection, &labels, start_ns, end_ns, &metric_name);
+        if result.is_empty() {
+            return Err(QueryError::MetricNotFound(format!(
+                "No histogram data found for {metric_name}"
+            )));
+        }
+        Ok(QueryResult::Matrix { result })
+    }
+
     /// Handle `histogram_mean(metric{matchers}[, stride])` and
     /// `histogram_count(metric{matchers}[, stride])` queries.
     ///
@@ -481,6 +579,19 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         }
         if query_str.starts_with("histogram_count(") && query_str.ends_with(")") {
             return self.handle_histogram_scalar("histogram_count", query_str, start, end);
+        }
+
+        // `histogram_irate` is a rezolus extension — promql-parser
+        // doesn't know the name, so a nested form like
+        // `sum(histogram_irate(m))` never reaches the dispatcher.
+        // Since `histogram_irate` already collapses every matching
+        // series into a single output, the outer `sum(...)` (or
+        // `sum by (..)(...)` / `sum without (..)(...)`) wrapper is
+        // functionally a no-op; strip it here so the idiomatic
+        // dashboard form parses.
+        let effective = strip_outer_sum_around_histogram_irate(query_str).unwrap_or(query_str);
+        if effective.starts_with("histogram_irate(") && effective.ends_with(")") {
+            return self.handle_histogram_irate(effective, start, end);
         }
 
         // Parse the query into an AST and evaluate. The streaming

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -123,42 +123,110 @@ fn split_last_top_level_comma(s: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// Strip an outer `sum(...)` / `sum by (..)(...)` / `sum without (..)(...)`
-/// wrapper if the inner call is `histogram_irate(...)`. The wrapper is a
-/// no-op since `histogram_irate` already collapses to one series; this lets
-/// `sum(histogram_irate(m))` parse even though promql-parser doesn't know
-/// the function name.
-fn strip_outer_sum_around_histogram_irate(query: &str) -> Option<&str> {
-    let rest = query.trim().strip_prefix("sum")?.trim_start();
+/// Owned grouping spec for the rezolus histogram reducers, parsed
+/// from `by (..)` / `without (..)` modifiers in `query_range`.
+/// Borrowed as a `streaming::GroupBy<'_>` at call sites.
+#[derive(Debug, Default, Clone)]
+pub(crate) enum HistogramGroupBy {
+    #[default]
+    None,
+    By(Vec<String>),
+    Without(Vec<String>),
+}
 
-    let body = if let Some(r) = rest.strip_prefix("by") {
-        let r = r.trim_start().strip_prefix('(')?;
-        let close = find_top_level_close_paren(r)?;
-        r[close + 1..].trim_start()
-    } else if let Some(r) = rest.strip_prefix("without") {
-        let r = r.trim_start().strip_prefix('(')?;
-        let close = find_top_level_close_paren(r)?;
-        r[close + 1..].trim_start()
-    } else {
-        rest
-    };
-
-    let body = body.strip_prefix('(')?;
-    let close = find_top_level_close_paren(body)?;
-    if close != body.len() - 1 {
-        return None;
-    }
-    let inner = body[..close].trim();
-    if inner.starts_with("histogram_irate(") && inner.ends_with(')') {
-        Some(inner)
-    } else {
-        None
+impl HistogramGroupBy {
+    pub(crate) fn as_ref(&self) -> streaming::GroupBy<'_> {
+        match self {
+            HistogramGroupBy::None => streaming::GroupBy::Include(&[]),
+            HistogramGroupBy::By(ls) => streaming::GroupBy::Include(ls),
+            HistogramGroupBy::Without(ls) => streaming::GroupBy::Exclude(ls),
+        }
     }
 }
 
-/// Find the `)` that closes the open paren whose content starts at byte 0
-/// of `s` (depth begins at 1). `None` if unbalanced.
-fn find_top_level_close_paren(s: &str) -> Option<usize> {
+/// Parse a rezolus histogram call of shape
+/// `<func> [by (labels) | without (labels)] (...body...)` and return
+/// the inner body (without the outer parens) plus the grouping.
+/// Returns `Ok(None)` if `query` doesn't start with `<func>`.
+pub(crate) fn parse_histogram_call<'a>(
+    func: &str,
+    query: &'a str,
+) -> Result<Option<(&'a str, HistogramGroupBy)>, QueryError> {
+    let Some(after_name) = query.strip_prefix(func) else {
+        return Ok(None);
+    };
+    // Reject prefix matches against longer function names (e.g. don't
+    // let "histogram_count_extra(" match func="histogram_count").
+    let next = after_name.chars().next();
+    if !matches!(next, Some('(') | Some(' ') | Some('\t')) {
+        return Ok(None);
+    }
+    let rest = after_name.trim_start();
+
+    let (group_by, after_modifier) = if let Some(r) = rest.strip_prefix("by") {
+        let r = r.trim_start();
+        let inside = r
+            .strip_prefix('(')
+            .ok_or_else(|| QueryError::ParseError(format!("{func}: expected '(' after 'by'")))?;
+        let close = find_close_paren(inside).ok_or_else(|| {
+            QueryError::ParseError(format!("{func}: unbalanced parens in 'by' clause"))
+        })?;
+        let labels = parse_label_list(&inside[..close])?;
+        (
+            HistogramGroupBy::By(labels),
+            inside[close + 1..].trim_start(),
+        )
+    } else if let Some(r) = rest.strip_prefix("without") {
+        let r = r.trim_start();
+        let inside = r.strip_prefix('(').ok_or_else(|| {
+            QueryError::ParseError(format!("{func}: expected '(' after 'without'"))
+        })?;
+        let close = find_close_paren(inside).ok_or_else(|| {
+            QueryError::ParseError(format!("{func}: unbalanced parens in 'without' clause"))
+        })?;
+        let labels = parse_label_list(&inside[..close])?;
+        (
+            HistogramGroupBy::Without(labels),
+            inside[close + 1..].trim_start(),
+        )
+    } else {
+        (HistogramGroupBy::None, rest)
+    };
+
+    let body = after_modifier.strip_prefix('(').ok_or_else(|| {
+        QueryError::ParseError(format!("{func}: expected '(' after function name"))
+    })?;
+    if !body.ends_with(')') {
+        return Err(QueryError::ParseError(format!(
+            "{func}: missing closing ')'"
+        )));
+    }
+    let inner = &body[..body.len() - 1];
+    Ok(Some((inner, group_by)))
+}
+
+/// Parse a comma-separated list of label identifiers. Empty entries
+/// are skipped (`by ()` is allowed, meaning "no labels").
+fn parse_label_list(s: &str) -> Result<Vec<String>, QueryError> {
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let p = part.trim();
+        if p.is_empty() {
+            continue;
+        }
+        if !p.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            return Err(QueryError::ParseError(format!(
+                "invalid label name in grouping clause: {p}"
+            )));
+        }
+        out.push(p.to_string());
+    }
+    Ok(out)
+}
+
+/// Find the `)` that closes the open paren whose content starts at
+/// byte 0 of `s` (depth begins at 1). `None` if unbalanced.
+fn find_close_paren(s: &str) -> Option<usize> {
     let mut depth: usize = 1;
     for (i, ch) in s.char_indices() {
         match ch {
@@ -456,16 +524,16 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         }
     }
 
-    /// Handle `histogram_irate(metric{matchers})`. Same metric-selector
-    /// shape as `histogram_count` / `histogram_mean`, but rejects a
-    /// trailing stride — see [`streaming::histogram::irate`].
+    /// Handle `histogram_irate(metric{matchers}) [by/without (..)]`.
+    /// Same shape as `histogram_count` / `histogram_mean`, but rejects
+    /// a trailing stride — see [`streaming::histogram::irate`].
     fn handle_histogram_irate(
         &self,
-        query_str: &str,
+        inner: &str,
+        group_by: HistogramGroupBy,
         start: f64,
         end: f64,
     ) -> Result<QueryResult, QueryError> {
-        let inner = &query_str["histogram_irate(".len()..query_str.len() - 1];
         let (metric_selector, stride_ns) = parse_optional_stride(inner.trim())?;
         if stride_ns.is_some() {
             return Err(QueryError::ParseError(
@@ -480,8 +548,14 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
 
         let start_ns = (start * 1e9) as u64;
         let end_ns = (end * 1e9) as u64;
-        let result =
-            streaming::histogram::irate(collection, &labels, start_ns, end_ns, &metric_name);
+        let result = streaming::histogram::irate(
+            collection,
+            &labels,
+            group_by.as_ref(),
+            start_ns,
+            end_ns,
+            &metric_name,
+        );
         if result.is_empty() {
             return Err(QueryError::MetricNotFound(format!(
                 "No histogram data found for {metric_name}"
@@ -490,23 +564,19 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         Ok(QueryResult::Matrix { result })
     }
 
-    /// Handle `histogram_mean(metric{matchers}[, stride])` and
-    /// `histogram_count(metric{matchers}[, stride])` queries.
-    ///
-    /// Both collapse every matching label-keyed series into a single
-    /// output series labeled `{__name__: metric_name}` — `mean` emits
-    /// the count-weighted bucket-midpoint mean per tick, `count` the
-    /// total observation count per tick. Same single-metric-arg
-    /// pre-parser shape as `histogram_heatmap`, reusing the streaming
-    /// per-tick walk so peak memory is independent of series count.
+    /// Handle `histogram_mean(metric{matchers}[, stride]) [by/without (..)]`
+    /// and `histogram_count(metric{matchers}[, stride]) [by/without (..)]`.
+    /// With no grouping, every matching series collapses into one
+    /// `{__name__: metric_name}` output; with `by`/`without`, one series
+    /// per distinct projected-label tuple.
     fn handle_histogram_scalar(
         &self,
         func: &str,
-        query_str: &str,
+        inner: &str,
+        group_by: HistogramGroupBy,
         start: f64,
         end: f64,
     ) -> Result<QueryResult, QueryError> {
-        let inner = &query_str[func.len() + 1..query_str.len() - 1];
         let (metric_selector, stride_ns) = parse_optional_stride(inner.trim())?;
         let (metric_name, labels) = self.parse_metric_selector(metric_selector)?;
 
@@ -516,10 +586,12 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
 
         let start_ns = (start * 1e9) as u64;
         let end_ns = (end * 1e9) as u64;
+        let group = group_by.as_ref();
         let result = match func {
             "histogram_mean" => streaming::histogram::mean(
                 collection,
                 &labels,
+                group,
                 start_ns,
                 end_ns,
                 stride_ns,
@@ -528,6 +600,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             _ => streaming::histogram::count(
                 collection,
                 &labels,
+                group,
                 start_ns,
                 end_ns,
                 stride_ns,
@@ -560,21 +633,17 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             return self.handle_histogram_heatmap(query_str, start, end);
         }
 
-        // Scalar histogram reducers (rezolus extensions, same
-        // single-metric-arg shape as histogram_heatmap).
-        if query_str.starts_with("histogram_mean(") && query_str.ends_with(")") {
-            return self.handle_histogram_scalar("histogram_mean", query_str, start, end);
+        // Scalar histogram reducers (rezolus extensions). Each accepts
+        // an optional aggregation-modifier clause `[by/without (..)]`
+        // between the function name and the metric body, mirroring the
+        // PromQL aggregation-operator syntax.
+        for func in ["histogram_mean", "histogram_count"] {
+            if let Some((inner, group_by)) = parse_histogram_call(func, query_str)? {
+                return self.handle_histogram_scalar(func, inner, group_by, start, end);
+            }
         }
-        if query_str.starts_with("histogram_count(") && query_str.ends_with(")") {
-            return self.handle_histogram_scalar("histogram_count", query_str, start, end);
-        }
-
-        // promql-parser doesn't know `histogram_irate`, so peel a
-        // no-op outer `sum`/`sum by`/`sum without` wrapper here so
-        // the dashboard idiom `sum(histogram_irate(m))` parses.
-        let effective = strip_outer_sum_around_histogram_irate(query_str).unwrap_or(query_str);
-        if effective.starts_with("histogram_irate(") && effective.ends_with(")") {
-            return self.handle_histogram_irate(effective, start, end);
+        if let Some((inner, group_by)) = parse_histogram_call("histogram_irate", query_str)? {
+            return self.handle_histogram_irate(inner, group_by, start, end);
         }
 
         // Parse the query into an AST and evaluate. The streaming

--- a/metriken-query/src/promql/streaming/aggregate.rs
+++ b/metriken-query/src/promql/streaming/aggregate.rs
@@ -70,7 +70,7 @@ pub fn aggregate<'a>(input: SeriesSet<'a>, op: AggOp, group_by: GroupBy<'_>) -> 
         .collect()
 }
 
-fn derive_group_labels(labels: &Labels, group_by: GroupBy<'_>) -> Labels {
+pub(crate) fn derive_group_labels(labels: &Labels, group_by: GroupBy<'_>) -> Labels {
     let mut out = Labels::default();
     match group_by {
         GroupBy::Include(by) => {

--- a/metriken-query/src/promql/streaming/histogram.rs
+++ b/metriken-query/src/promql/streaming/histogram.rs
@@ -35,6 +35,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use ::histogram::{Config, CumulativeROHistogram32Ref, Quantile, QuantilesResult};
 
+use crate::promql::streaming::{derive_group_labels, GroupBy};
 use crate::promql::MatrixSample;
 use crate::tsdb::{HistogramCollection, Labels};
 
@@ -338,16 +339,18 @@ fn apply_quantiles_ref(
     }
 }
 
-/// Streaming `histogram_mean(metric{filter}[, stride])`.
+/// Streaming `histogram_mean(metric{filter}[, stride]) [by/without (..)]`.
 ///
-/// Emits one series, labeled `{__name__: metric_name}`, whose value
-/// at each tick is the bucket-midpoint mean of the (summed, per-tick
-/// delta) histogram. Read off the merged `Ref`'s cached `mean()`
-/// field — populated once at Ref construction by the histogram
-/// crate, so the per-tick read here is O(1).
+/// With no grouping modifier, emits one series labeled
+/// `{__name__: metric_name}` whose value at each tick is the
+/// bucket-midpoint mean of the (summed, per-tick delta) histogram.
+/// With `by`/`without`, emits one such series per distinct projected
+/// label tuple. Read off the merged `Ref`'s cached `mean()` field —
+/// populated once at Ref construction, so the per-tick read is O(1).
 pub fn mean(
     collection: &HistogramCollection,
     label_filter: &Labels,
+    group_by: GroupBy<'_>,
     start_ns: u64,
     end_ns: u64,
     stride_ns: Option<u64>,
@@ -356,6 +359,7 @@ pub fn mean(
     reduce(
         collection,
         label_filter,
+        group_by,
         start_ns,
         end_ns,
         stride_ns,
@@ -364,15 +368,15 @@ pub fn mean(
     )
 }
 
-/// Streaming `histogram_count(metric{filter}[, stride])`.
+/// Streaming `histogram_count(metric{filter}[, stride]) [by/without (..)]`.
 ///
-/// Emits one series, labeled `{__name__: metric_name}`, whose value
-/// at each tick is the total number of observations in the (summed,
-/// per-tick delta) histogram — i.e. `QuantilesResult::total_count`,
-/// read directly off the merged `Ref` without a quantile walk.
+/// Same shape as [`mean`] but emits the total observation count per
+/// (group, tick) — `QuantilesResult::total_count` read directly off
+/// the merged `Ref`, no quantile walk.
 pub fn count(
     collection: &HistogramCollection,
     label_filter: &Labels,
+    group_by: GroupBy<'_>,
     start_ns: u64,
     end_ns: u64,
     stride_ns: Option<u64>,
@@ -381,6 +385,7 @@ pub fn count(
     reduce(
         collection,
         label_filter,
+        group_by,
         start_ns,
         end_ns,
         stride_ns,
@@ -395,27 +400,33 @@ pub fn count(
 /// Shared per-tick walk for scalar histogram reducers
 /// (`histogram_mean`, `histogram_count`).
 ///
-/// Identical tick/stride/multi-series merge logic to [`quantiles`],
-/// but instead of running the quantile reducer it applies `reducer`
-/// to the per-tick merged `Ref` and appends a single `(t_sec, value)`
-/// point. Returns one [`MatrixSample`] labeled
-/// `{__name__: metric_name}`, or an empty `Vec` when no tick yields
-/// a value (empty range, no matching series, all-empty deltas).
+/// Same tick/stride/multi-series merge logic as [`quantiles`], but
+/// applies `reducer` to each per-group merged `Ref` and emits one
+/// `(t_sec, value)` point per group per tick. Returns one
+/// [`MatrixSample`] per non-empty group.
+#[allow(clippy::too_many_arguments)]
 fn reduce(
     collection: &HistogramCollection,
     label_filter: &Labels,
+    group_by: GroupBy<'_>,
     start_ns: u64,
     end_ns: u64,
     stride_ns: Option<u64>,
     metric_name: &str,
     reducer: impl Fn(&CumulativeROHistogram32Ref<'_>) -> Option<f64>,
 ) -> Vec<MatrixSample> {
+    let mut group_keys: Vec<Labels> = Vec::new();
+    let mut series_group: Vec<usize> = Vec::new();
     let mut iters: Vec<_> = collection
         .iter()
         .filter(|(labels, _)| label_filter.inner.is_empty() || labels.matches(label_filter))
-        .map(|(_, series)| series.iter().peekable())
+        .map(|(labels, series)| {
+            let key = derive_group_labels(labels, group_by);
+            series_group.push(assign_group_index(&mut group_keys, key));
+            series.iter().peekable()
+        })
         .collect();
-
+    let g_count = group_keys.len();
     if iters.is_empty() {
         return vec![];
     }
@@ -428,17 +439,16 @@ fn reduce(
         return vec![];
     };
 
-    let mut values: Vec<(f64, f64)> = Vec::new();
-    let mut emit = |r: &CumulativeROHistogram32Ref<'_>, t_ns: u64| {
-        if let Some(v) = reducer(r) {
-            values.push((t_ns as f64 / 1e9, v));
-        }
-    };
-
+    let mut values_per_group: Vec<Vec<(f64, f64)>> = (0..g_count).map(|_| Vec::new()).collect();
     let mut scratch_idx: Vec<u32> = Vec::new();
     let mut scratch_cnt: Vec<u32> = Vec::new();
 
-    let mut stride_accum: BTreeMap<u32, u64> = BTreeMap::new();
+    // Per-group bucket accumulator. In no-stride mode it's reset every
+    // tick; in stride mode it persists across ticks within the stride
+    // window. One BTreeMap per group — peak grows with group count
+    // but stays independent of input series cardinality.
+    let mut accum_per_group: Vec<BTreeMap<u32, u64>> =
+        (0..g_count).map(|_| BTreeMap::new()).collect();
     let mut stride_last_emit: Option<u64> = None;
     let mut stride_end_time: u64 = 0;
 
@@ -465,20 +475,23 @@ fn reduce(
             continue;
         }
 
-        let mut at_t: Vec<CumulativeROHistogram32Ref<'_>> = Vec::new();
-        for it in iters.iter_mut() {
+        // In no-stride mode each tick's per-group accumulator is
+        // independent; clear before refilling.
+        if stride_ns.is_none() {
+            for accum in accum_per_group.iter_mut() {
+                accum.clear();
+            }
+        }
+
+        for (i, it) in iters.iter_mut().enumerate() {
             if matches!(it.peek(), Some(&(ts, _)) if ts == t) {
                 let (_, r) = it.next().expect("peek matched");
-                at_t.push(r);
+                accumulate_into(&mut accum_per_group[series_group[i]], &r);
             }
         }
 
         if let Some(stride) = stride_ns {
-            for r in &at_t {
-                accumulate_into(&mut stride_accum, r);
-            }
             stride_end_time = t;
-
             let last = match stride_last_emit {
                 Some(t) => t,
                 None => {
@@ -487,54 +500,100 @@ fn reduce(
                 }
             };
             if t >= last && t - last >= stride {
-                if flush_accum(&mut stride_accum, &mut scratch_idx, &mut scratch_cnt) {
-                    let r = CumulativeROHistogram32Ref::from_parts_unchecked(
-                        config,
-                        &scratch_idx,
-                        &scratch_cnt,
-                    );
-                    emit(&r, stride_end_time);
+                for g in 0..g_count {
+                    if flush_accum(&mut accum_per_group[g], &mut scratch_idx, &mut scratch_cnt) {
+                        let r = CumulativeROHistogram32Ref::from_parts_unchecked(
+                            config,
+                            &scratch_idx,
+                            &scratch_cnt,
+                        );
+                        if let Some(v) = reducer(&r) {
+                            values_per_group[g].push((stride_end_time as f64 / 1e9, v));
+                        }
+                    }
                 }
                 stride_last_emit = Some(t);
             }
         } else {
-            match at_t.len() {
-                1 => emit(&at_t[0], t),
-                _ => {
-                    merge_into(&at_t, &mut scratch_idx, &mut scratch_cnt);
+            for g in 0..g_count {
+                if flush_accum(&mut accum_per_group[g], &mut scratch_idx, &mut scratch_cnt) {
                     let r = CumulativeROHistogram32Ref::from_parts_unchecked(
                         config,
                         &scratch_idx,
                         &scratch_cnt,
                     );
-                    emit(&r, t);
+                    if let Some(v) = reducer(&r) {
+                        values_per_group[g].push((t as f64 / 1e9, v));
+                    }
                 }
             }
         }
     }
 
-    if stride_ns.is_some()
-        && !stride_accum.is_empty()
-        && flush_accum(&mut stride_accum, &mut scratch_idx, &mut scratch_cnt)
-    {
-        let r =
-            CumulativeROHistogram32Ref::from_parts_unchecked(config, &scratch_idx, &scratch_cnt);
-        emit(&r, stride_end_time);
+    if stride_ns.is_some() {
+        for g in 0..g_count {
+            if flush_accum(&mut accum_per_group[g], &mut scratch_idx, &mut scratch_cnt) {
+                let r = CumulativeROHistogram32Ref::from_parts_unchecked(
+                    config,
+                    &scratch_idx,
+                    &scratch_cnt,
+                );
+                if let Some(v) = reducer(&r) {
+                    values_per_group[g].push((stride_end_time as f64 / 1e9, v));
+                }
+            }
+        }
     }
 
-    if values.is_empty() {
-        return vec![];
-    }
-    let mut metric: HashMap<String, String> = HashMap::new();
-    metric.insert("__name__".to_string(), metric_name.to_string());
-    vec![MatrixSample { metric, values }]
+    build_grouped_output(metric_name, group_keys, values_per_group)
 }
 
-/// Streaming `histogram_irate(metric{filter})`.
+/// Look up `key` in `group_keys`; insert and return a new index if
+/// absent. Used during series-list build to assign each input series
+/// to a group slot without a hashmap (group cardinality is small —
+/// linear scan beats hashing for the typical few-groups case).
+fn assign_group_index(group_keys: &mut Vec<Labels>, key: Labels) -> usize {
+    match group_keys.iter().position(|k| k == &key) {
+        Some(i) => i,
+        None => {
+            group_keys.push(key);
+            group_keys.len() - 1
+        }
+    }
+}
+
+/// Assemble per-group `(timestamps, values)` into one [`MatrixSample`]
+/// each, dropping empty groups and writing `__name__` plus the group
+/// key labels into the output metric.
+fn build_grouped_output(
+    metric_name: &str,
+    group_keys: Vec<Labels>,
+    values_per_group: Vec<Vec<(f64, f64)>>,
+) -> Vec<MatrixSample> {
+    let mut samples = Vec::new();
+    for (key, values) in group_keys.into_iter().zip(values_per_group) {
+        if values.is_empty() {
+            continue;
+        }
+        let mut metric: HashMap<String, String> = HashMap::new();
+        metric.insert("__name__".to_string(), metric_name.to_string());
+        for (k, v) in key.inner {
+            metric.insert(k, v);
+        }
+        samples.push(MatrixSample { metric, values });
+    }
+    samples
+}
+
+/// Streaming `histogram_irate(metric{filter}) [by/without (..)]`.
 ///
-/// Per-step rate of the cumulative sample count, emitted as a single
-/// series `{__name__: metric_name}`. At each tick `t` the value is
-/// `sum(total_count()) / (t - t_prev)`.
+/// Per-step rate of the cumulative sample count. With no grouping
+/// modifier every matching series collapses into one output
+/// `{__name__: metric_name}`; with `by`/`without` one series is
+/// emitted per distinct projected-label tuple.
+///
+/// At each tick `t`, each group's value is
+/// `sum(total_count over group) / (t - t_prev_for_group)`.
 ///
 /// First tick → no point. Idle tick (empty delta) → `0` (differs
 /// from `histogram_mean`, which is null on empty).
@@ -551,25 +610,35 @@ fn reduce(
 pub fn irate(
     collection: &HistogramCollection,
     label_filter: &Labels,
+    group_by: GroupBy<'_>,
     start_ns: u64,
     end_ns: u64,
     metric_name: &str,
 ) -> Vec<MatrixSample> {
+    let mut group_keys: Vec<Labels> = Vec::new();
+    let mut series_group: Vec<usize> = Vec::new();
     let mut iters: Vec<_> = collection
         .iter()
         .filter(|(labels, _)| label_filter.inner.is_empty() || labels.matches(label_filter))
-        .map(|(_, series)| series.iter().peekable())
+        .map(|(labels, series)| {
+            let key = derive_group_labels(labels, group_by);
+            series_group.push(assign_group_index(&mut group_keys, key));
+            series.iter().peekable()
+        })
         .collect();
-
+    let g_count = group_keys.len();
     if iters.is_empty() {
         return vec![];
     }
 
-    let mut values: Vec<(f64, f64)> = Vec::new();
-    // Updated even for pre-window ticks, so the first in-window
-    // tick can still produce a rate against the last pre-window
-    // sample (PromQL rate looks backward past the window edge).
-    let mut prev_t_ns: Option<u64> = None;
+    // Per-group state, indexed by group_idx.
+    let mut values_per_group: Vec<Vec<(f64, f64)>> = (0..g_count).map(|_| Vec::new()).collect();
+    // Updated even for pre-window ticks so the first in-window tick
+    // can still produce a rate against the last pre-window sample.
+    let mut prev_t_per_group: Vec<Option<u64>> = vec![None; g_count];
+    // Per-tick scratch reused every iteration; sized once.
+    let mut tick_count_per_group: Vec<u64> = vec![0; g_count];
+    let mut tick_has_data: Vec<bool> = vec![false; g_count];
 
     loop {
         let mut min_ts: Option<u64> = None;
@@ -585,40 +654,49 @@ pub fn irate(
         }
         let Some(t) = min_ts else { break };
 
-        // Sum total_count across series at t — skip the bucket
-        // merge the quantile/mean paths need.
-        let mut count: u64 = 0;
-        for it in iters.iter_mut() {
+        for c in tick_count_per_group.iter_mut() {
+            *c = 0;
+        }
+        for h in tick_has_data.iter_mut() {
+            *h = false;
+        }
+
+        for (i, it) in iters.iter_mut().enumerate() {
             if matches!(it.peek(), Some(&(ts, _)) if ts == t) {
                 let (_, r) = it.next().expect("peek matched");
-                count = count.saturating_add(r.total_count());
+                let g = series_group[i];
+                tick_count_per_group[g] = tick_count_per_group[g].saturating_add(r.total_count());
+                tick_has_data[g] = true;
             }
         }
 
         if t < start_ns {
-            prev_t_ns = Some(t);
+            for (g, &has) in tick_has_data.iter().enumerate() {
+                if has {
+                    prev_t_per_group[g] = Some(t);
+                }
+            }
             continue;
         }
 
-        if let Some(prev) = prev_t_ns {
-            let dt_ns = t.saturating_sub(prev);
-            if dt_ns > 0 {
-                let dt_sec = dt_ns as f64 / 1e9;
-                // count is u64 so already non-negative; .max(0.0)
-                // documents the cumulative-form negative-delta clamp.
-                let rate = (count as f64).max(0.0) / dt_sec;
-                values.push((t as f64 / 1e9, rate));
+        for g in 0..g_count {
+            if !tick_has_data[g] {
+                continue;
             }
+            if let Some(prev) = prev_t_per_group[g] {
+                let dt_ns = t.saturating_sub(prev);
+                if dt_ns > 0 {
+                    // count is u64 so already non-negative; .max(0.0)
+                    // documents the cumulative-form negative-delta clamp.
+                    let rate = (tick_count_per_group[g] as f64).max(0.0) / (dt_ns as f64 / 1e9);
+                    values_per_group[g].push((t as f64 / 1e9, rate));
+                }
+            }
+            prev_t_per_group[g] = Some(t);
         }
-        prev_t_ns = Some(t);
     }
 
-    if values.is_empty() {
-        return vec![];
-    }
-    let mut metric: HashMap<String, String> = HashMap::new();
-    metric.insert("__name__".to_string(), metric_name.to_string());
-    vec![MatrixSample { metric, values }]
+    build_grouped_output(metric_name, group_keys, values_per_group)
 }
 
 /// Streaming `histogram_heatmap(metric{filter}[, stride])`.

--- a/metriken-query/src/promql/streaming/histogram.rs
+++ b/metriken-query/src/promql/streaming/histogram.rs
@@ -339,14 +339,9 @@ fn apply_quantiles_ref(
     }
 }
 
-/// Streaming `histogram_mean(metric{filter}[, stride]) [by/without (..)]`.
-///
-/// With no grouping modifier, emits one series labeled
-/// `{__name__: metric_name}` whose value at each tick is the
-/// bucket-midpoint mean of the (summed, per-tick delta) histogram.
-/// With `by`/`without`, emits one such series per distinct projected
-/// label tuple. Read off the merged `Ref`'s cached `mean()` field —
-/// populated once at Ref construction, so the per-tick read is O(1).
+/// Bucket-midpoint mean per `(group, tick)`. The per-tick read uses
+/// the `Ref`'s cached `mean()` field — populated once at construction,
+/// so it's O(1) regardless of bucket count.
 pub fn mean(
     collection: &HistogramCollection,
     label_filter: &Labels,
@@ -368,10 +363,7 @@ pub fn mean(
     )
 }
 
-/// Streaming `histogram_count(metric{filter}[, stride]) [by/without (..)]`.
-///
-/// Same shape as [`mean`] but emits the total observation count per
-/// (group, tick) — `QuantilesResult::total_count` read directly off
+/// Total observation count per `(group, tick)` — `total_count()` off
 /// the merged `Ref`, no quantile walk.
 pub fn count(
     collection: &HistogramCollection,
@@ -397,13 +389,8 @@ pub fn count(
     )
 }
 
-/// Shared per-tick walk for scalar histogram reducers
-/// (`histogram_mean`, `histogram_count`).
-///
-/// Same tick/stride/multi-series merge logic as [`quantiles`], but
-/// applies `reducer` to each per-group merged `Ref` and emits one
-/// `(t_sec, value)` point per group per tick. Returns one
-/// [`MatrixSample`] per non-empty group.
+/// Per-tick / per-group merge driver shared by [`mean`] and [`count`].
+/// Mirrors [`quantiles`] but applies `reducer` to the merged group `Ref`.
 #[allow(clippy::too_many_arguments)]
 fn reduce(
     collection: &HistogramCollection,
@@ -443,10 +430,7 @@ fn reduce(
     let mut scratch_idx: Vec<u32> = Vec::new();
     let mut scratch_cnt: Vec<u32> = Vec::new();
 
-    // Per-group bucket accumulator. In no-stride mode it's reset every
-    // tick; in stride mode it persists across ticks within the stride
-    // window. One BTreeMap per group — peak grows with group count
-    // but stays independent of input series cardinality.
+    // Persists across ticks in stride mode; cleared each tick otherwise.
     let mut accum_per_group: Vec<BTreeMap<u32, u64>> =
         (0..g_count).map(|_| BTreeMap::new()).collect();
     let mut stride_last_emit: Option<u64> = None;
@@ -475,8 +459,6 @@ fn reduce(
             continue;
         }
 
-        // In no-stride mode each tick's per-group accumulator is
-        // independent; clear before refilling.
         if stride_ns.is_none() {
             for accum in accum_per_group.iter_mut() {
                 accum.clear();
@@ -548,10 +530,7 @@ fn reduce(
     build_grouped_output(metric_name, group_keys, values_per_group)
 }
 
-/// Look up `key` in `group_keys`; insert and return a new index if
-/// absent. Used during series-list build to assign each input series
-/// to a group slot without a hashmap (group cardinality is small —
-/// linear scan beats hashing for the typical few-groups case).
+/// Linear scan beats hashing at the group cardinalities we see.
 fn assign_group_index(group_keys: &mut Vec<Labels>, key: Labels) -> usize {
     match group_keys.iter().position(|k| k == &key) {
         Some(i) => i,
@@ -562,9 +541,6 @@ fn assign_group_index(group_keys: &mut Vec<Labels>, key: Labels) -> usize {
     }
 }
 
-/// Assemble per-group `(timestamps, values)` into one [`MatrixSample`]
-/// each, dropping empty groups and writing `__name__` plus the group
-/// key labels into the output metric.
 fn build_grouped_output(
     metric_name: &str,
     group_keys: Vec<Labels>,
@@ -585,28 +561,20 @@ fn build_grouped_output(
     samples
 }
 
-/// Streaming `histogram_irate(metric{filter}) [by/without (..)]`.
+/// Per-step rate of the cumulative sample count, per group.
+/// `sum(total_count over group) / (t - t_prev_for_group)` each tick.
 ///
-/// Per-step rate of the cumulative sample count. With no grouping
-/// modifier every matching series collapses into one output
-/// `{__name__: metric_name}`; with `by`/`without` one series is
-/// emitted per distinct projected-label tuple.
-///
-/// At each tick `t`, each group's value is
-/// `sum(total_count over group) / (t - t_prev_for_group)`.
-///
-/// First tick → no point. Idle tick (empty delta) → `0` (differs
-/// from `histogram_mean`, which is null on empty).
+/// First tick → no point. Idle tick → `0` (differs from
+/// `histogram_mean`, which is null on empty).
 ///
 /// No window argument: `sum(irate(histogram_count(m)[5m]))` doesn't
 /// parse — PromQL disallows range vectors on function-call results —
 /// and metriken stores one delta per tick anyway, so a range would
 /// always cover exactly one sample.
 ///
-/// A lock-free snapshot undercount in the upstream counter would
-/// produce a negative delta in cumulative form; the ingest layer's
-/// `delta_to_32_or_empty` already turns that into an empty delta,
-/// so the irate value naturally falls out as 0.
+/// Negative-delta clamp: a lock-free snapshot undercount in the
+/// upstream counter is absorbed into an empty delta at ingest
+/// (`delta_to_32_or_empty`), so the rate naturally falls out as 0.
 pub fn irate(
     collection: &HistogramCollection,
     label_filter: &Labels,
@@ -631,12 +599,10 @@ pub fn irate(
         return vec![];
     }
 
-    // Per-group state, indexed by group_idx.
     let mut values_per_group: Vec<Vec<(f64, f64)>> = (0..g_count).map(|_| Vec::new()).collect();
-    // Updated even for pre-window ticks so the first in-window tick
-    // can still produce a rate against the last pre-window sample.
+    // Updated even for pre-window ticks, so the first in-window tick
+    // can rate against the last pre-window sample.
     let mut prev_t_per_group: Vec<Option<u64>> = vec![None; g_count];
-    // Per-tick scratch reused every iteration; sized once.
     let mut tick_count_per_group: Vec<u64> = vec![0; g_count];
     let mut tick_has_data: Vec<bool> = vec![false; g_count];
 
@@ -686,8 +652,8 @@ pub fn irate(
             if let Some(prev) = prev_t_per_group[g] {
                 let dt_ns = t.saturating_sub(prev);
                 if dt_ns > 0 {
-                    // count is u64 so already non-negative; .max(0.0)
-                    // documents the cumulative-form negative-delta clamp.
+                    // .max(0.0) documents the cumulative-form clamp;
+                    // count is u64 so already non-negative.
                     let rate = (tick_count_per_group[g] as f64).max(0.0) / (dt_ns as f64 / 1e9);
                     values_per_group[g].push((t as f64 / 1e9, rate));
                 }

--- a/metriken-query/src/promql/streaming/histogram.rs
+++ b/metriken-query/src/promql/streaming/histogram.rs
@@ -532,33 +532,22 @@ fn reduce(
 
 /// Streaming `histogram_irate(metric{filter})`.
 ///
-/// Per-step rate of the cumulative sample count, returned as a
-/// single-series instant vector labeled `{__name__: metric_name}`.
-/// At each tick `t`, the emitted value is
-/// `count_delta(t) / (t - t_prev)` where `count_delta(t)` is the
-/// sum of `total_count()` over every series-at-`t` (the stored
-/// per-tick deltas already collapse across input series).
+/// Per-step rate of the cumulative sample count, emitted as a single
+/// series `{__name__: metric_name}`. At each tick `t` the value is
+/// `sum(total_count()) / (t - t_prev)`.
 ///
-/// First tick (no prior sample) emits nothing — the rate is
-/// undefined without a prior timestamp. Subsequent ticks with an
-/// empty delta emit `0` rather than being skipped (idle window
-/// has a well-defined zero rate; this differs from `histogram_mean`,
-/// which is null on empty because mean of nothing is undefined).
+/// First tick → no point. Idle tick (empty delta) → `0` (differs
+/// from `histogram_mean`, which is null on empty).
 ///
-/// No window/stride argument: the spec'd idiom
-/// `sum(irate(histogram_count(m)[5m]))` doesn't parse — PromQL
-/// disallows range vectors on function-call results — and metriken
-/// already evaluates one delta histogram per source tick, so a
-/// range argument would always cover exactly one sample. Dropping
-/// it sidesteps the grammar problem.
+/// No window argument: `sum(irate(histogram_count(m)[5m]))` doesn't
+/// parse — PromQL disallows range vectors on function-call results —
+/// and metriken stores one delta per tick anyway, so a range would
+/// always cover exactly one sample.
 ///
-/// The per-step delta count is `u64` and therefore never negative.
-/// Conceptually, a lock-free snapshot undercount in the upstream
-/// counter (next snapshot recovers and looks like a drop) would
-/// produce a transient negative delta in cumulative-count form;
-/// at ingest time `delta_to_32_or_empty` already absorbs that into
-/// an empty delta, so the irate value at that tick falls out as
-/// `0`. Acceptable for the fallback-rate role.
+/// A lock-free snapshot undercount in the upstream counter would
+/// produce a negative delta in cumulative form; the ingest layer's
+/// `delta_to_32_or_empty` already turns that into an empty delta,
+/// so the irate value naturally falls out as 0.
 pub fn irate(
     collection: &HistogramCollection,
     label_filter: &Labels,
@@ -577,11 +566,9 @@ pub fn irate(
     }
 
     let mut values: Vec<(f64, f64)> = Vec::new();
-    // Tracks the timestamp of the previous sample we saw — either
-    // an in-window tick we already emitted against, or a pre-window
-    // tick we skipped. The latter case lets the first in-window
-    // tick still produce a rate, mirroring how a PromQL rate query
-    // looks backward past the window edge for context.
+    // Updated even for pre-window ticks, so the first in-window
+    // tick can still produce a rate against the last pre-window
+    // sample (PromQL rate looks backward past the window edge).
     let mut prev_t_ns: Option<u64> = None;
 
     loop {
@@ -598,9 +585,8 @@ pub fn irate(
         }
         let Some(t) = min_ts else { break };
 
-        // Pull every series with a sample at t. We only need the
-        // total count per series, summed; the bucket-merge needed
-        // by the quantile/mean paths is skipped.
+        // Sum total_count across series at t — skip the bucket
+        // merge the quantile/mean paths need.
         let mut count: u64 = 0;
         for it in iters.iter_mut() {
             if matches!(it.peek(), Some(&(ts, _)) if ts == t) {
@@ -610,30 +596,18 @@ pub fn irate(
         }
 
         if t < start_ns {
-            // Pre-window tick: don't emit, but remember the
-            // timestamp so the first in-window tick has a `prev`
-            // to rate against.
             prev_t_ns = Some(t);
             continue;
         }
 
-        match prev_t_ns {
-            None => {
-                // First observed tick in the entire series — no
-                // prior timestamp, rate is undefined.
-            }
-            Some(prev) => {
-                let dt_ns = t.saturating_sub(prev);
-                if dt_ns > 0 {
-                    let dt_sec = dt_ns as f64 / 1e9;
-                    // `count` is u64 so already non-negative; the
-                    // .max(0.0) is a defensive clamp documenting
-                    // the conceptual cumulative-form behaviour
-                    // (negative delta → 0). See function-level
-                    // doc-comment.
-                    let rate = (count as f64).max(0.0) / dt_sec;
-                    values.push((t as f64 / 1e9, rate));
-                }
+        if let Some(prev) = prev_t_ns {
+            let dt_ns = t.saturating_sub(prev);
+            if dt_ns > 0 {
+                let dt_sec = dt_ns as f64 / 1e9;
+                // count is u64 so already non-negative; .max(0.0)
+                // documents the cumulative-form negative-delta clamp.
+                let rate = (count as f64).max(0.0) / dt_sec;
+                values.push((t as f64 / 1e9, rate));
             }
         }
         prev_t_ns = Some(t);

--- a/metriken-query/src/promql/streaming/histogram.rs
+++ b/metriken-query/src/promql/streaming/histogram.rs
@@ -530,6 +530,123 @@ fn reduce(
     vec![MatrixSample { metric, values }]
 }
 
+/// Streaming `histogram_irate(metric{filter})`.
+///
+/// Per-step rate of the cumulative sample count, returned as a
+/// single-series instant vector labeled `{__name__: metric_name}`.
+/// At each tick `t`, the emitted value is
+/// `count_delta(t) / (t - t_prev)` where `count_delta(t)` is the
+/// sum of `total_count()` over every series-at-`t` (the stored
+/// per-tick deltas already collapse across input series).
+///
+/// First tick (no prior sample) emits nothing — the rate is
+/// undefined without a prior timestamp. Subsequent ticks with an
+/// empty delta emit `0` rather than being skipped (idle window
+/// has a well-defined zero rate; this differs from `histogram_mean`,
+/// which is null on empty because mean of nothing is undefined).
+///
+/// No window/stride argument: the spec'd idiom
+/// `sum(irate(histogram_count(m)[5m]))` doesn't parse — PromQL
+/// disallows range vectors on function-call results — and metriken
+/// already evaluates one delta histogram per source tick, so a
+/// range argument would always cover exactly one sample. Dropping
+/// it sidesteps the grammar problem.
+///
+/// The per-step delta count is `u64` and therefore never negative.
+/// Conceptually, a lock-free snapshot undercount in the upstream
+/// counter (next snapshot recovers and looks like a drop) would
+/// produce a transient negative delta in cumulative-count form;
+/// at ingest time `delta_to_32_or_empty` already absorbs that into
+/// an empty delta, so the irate value at that tick falls out as
+/// `0`. Acceptable for the fallback-rate role.
+pub fn irate(
+    collection: &HistogramCollection,
+    label_filter: &Labels,
+    start_ns: u64,
+    end_ns: u64,
+    metric_name: &str,
+) -> Vec<MatrixSample> {
+    let mut iters: Vec<_> = collection
+        .iter()
+        .filter(|(labels, _)| label_filter.inner.is_empty() || labels.matches(label_filter))
+        .map(|(_, series)| series.iter().peekable())
+        .collect();
+
+    if iters.is_empty() {
+        return vec![];
+    }
+
+    let mut values: Vec<(f64, f64)> = Vec::new();
+    // Tracks the timestamp of the previous sample we saw — either
+    // an in-window tick we already emitted against, or a pre-window
+    // tick we skipped. The latter case lets the first in-window
+    // tick still produce a rate, mirroring how a PromQL rate query
+    // looks backward past the window edge for context.
+    let mut prev_t_ns: Option<u64> = None;
+
+    loop {
+        let mut min_ts: Option<u64> = None;
+        for it in iters.iter_mut() {
+            while let Some(&(ts, _)) = it.peek() {
+                if ts > end_ns {
+                    it.next();
+                    continue;
+                }
+                min_ts = Some(min_ts.map_or(ts, |m| m.min(ts)));
+                break;
+            }
+        }
+        let Some(t) = min_ts else { break };
+
+        // Pull every series with a sample at t. We only need the
+        // total count per series, summed; the bucket-merge needed
+        // by the quantile/mean paths is skipped.
+        let mut count: u64 = 0;
+        for it in iters.iter_mut() {
+            if matches!(it.peek(), Some(&(ts, _)) if ts == t) {
+                let (_, r) = it.next().expect("peek matched");
+                count = count.saturating_add(r.total_count());
+            }
+        }
+
+        if t < start_ns {
+            // Pre-window tick: don't emit, but remember the
+            // timestamp so the first in-window tick has a `prev`
+            // to rate against.
+            prev_t_ns = Some(t);
+            continue;
+        }
+
+        match prev_t_ns {
+            None => {
+                // First observed tick in the entire series — no
+                // prior timestamp, rate is undefined.
+            }
+            Some(prev) => {
+                let dt_ns = t.saturating_sub(prev);
+                if dt_ns > 0 {
+                    let dt_sec = dt_ns as f64 / 1e9;
+                    // `count` is u64 so already non-negative; the
+                    // .max(0.0) is a defensive clamp documenting
+                    // the conceptual cumulative-form behaviour
+                    // (negative delta → 0). See function-level
+                    // doc-comment.
+                    let rate = (count as f64).max(0.0) / dt_sec;
+                    values.push((t as f64 / 1e9, rate));
+                }
+            }
+        }
+        prev_t_ns = Some(t);
+    }
+
+    if values.is_empty() {
+        return vec![];
+    }
+    let mut metric: HashMap<String, String> = HashMap::new();
+    metric.insert("__name__".to_string(), metric_name.to_string());
+    vec![MatrixSample { metric, values }]
+}
+
 /// Streaming `histogram_heatmap(metric{filter}[, stride])`.
 ///
 /// Same per-tick walk as [`quantiles`] (sum across input series's

--- a/metriken-query/src/promql/streaming/mod.rs
+++ b/metriken-query/src/promql/streaming/mod.rs
@@ -47,6 +47,7 @@ mod rate;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use aggregate::derive_group_labels;
 pub use aggregate::{aggregate, sum_by, AggOp, GroupBy, MergeReduce};
 pub use binary::{matrix_matrix_op, matrix_scalar_op, BinOp, MatchSpec, ScalarBroadcast};
 pub use deriv::StreamingDeriv;

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1423,14 +1423,10 @@ fn test_histogram_mean_metric_not_found() {
     }
 }
 
-/// Build a TSDB where every snapshot increments the cumulative count
-/// by a fixed `step_increment` per second. Returns the tsdb plus the
-/// expected per-cpu count delta (across both CPUs, summed) that
-/// `histogram_irate` should see per tick.
-///
-/// All observations land in the exact bucket for value 10 (values
-/// < 32 are exact under grouping_power 4), matching the rest of the
-/// histogram exec fixtures.
+/// Two-cpu histogram TSDB driven by an explicit cumulative-count
+/// sequence; one snapshot per second starting at t=1000. All
+/// observations land in the exact bucket for value 10 (values < 32
+/// are exact under grouping_power 4).
 fn create_hist_irate_tsdb(cumulative_per_cpu: &[u64]) -> Tsdb {
     use histogram::Histogram;
     use metriken_exposition::{Histogram as SnapHist, Snapshot, SnapshotV2};
@@ -1470,10 +1466,9 @@ fn create_hist_irate_tsdb(cumulative_per_cpu: &[u64]) -> Tsdb {
 
 #[test]
 fn test_histogram_irate_steady_rate_is_constant() {
-    // Cumulative per cpu: [0, 10, 20, 30, 40] → per-tick deltas of 10
-    // per cpu = 20 per tick collapsed. At a 1s step, rate is 20.0
-    // every tick from the second observed delta onward. The first
-    // delta (t=1001) has no prior, so no point.
+    // Per-cpu deltas of +10/sec → 20/sec collapsed. The first delta
+    // (t=1001) has no prior, so the remaining three ticks each emit
+    // rate 20.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1491,10 +1486,6 @@ fn test_histogram_irate_steady_rate_is_constant() {
     );
 
     let values: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
-    // Stored deltas land at t=1001..=1004 (the loader drops the
-    // initial cumulative=0 snapshot since it has no predecessor).
-    // The first delta tick (t=1001) has no prior, so it's skipped;
-    // the remaining three emit a constant rate of 20 events/sec.
     assert_eq!(values.len(), 3, "first observed delta yields null");
     for v in values {
         assert!(
@@ -1506,17 +1497,8 @@ fn test_histogram_irate_steady_rate_is_constant() {
 
 #[test]
 fn test_histogram_irate_burst_then_idle_spikes_then_zero() {
-    // Cumulative per cpu: [0, 0, 50, 50, 50]
-    //   - delta at t=1001: 0 (loader stores explicit empty)
-    //   - delta at t=1002: 50 (burst)
-    //   - delta at t=1003: 0 (idle)
-    //   - delta at t=1004: 0 (idle)
-    // Summed across both cpus that's 0, 100, 0, 0.
-    //
-    // irate skips t=1001 (no prior), then:
-    //   t=1002: 100 / 1s = 100  (spike)
-    //   t=1003:   0 / 1s = 0    (idle)
-    //   t=1004:   0 / 1s = 0    (idle)
+    // Collapsed per-tick deltas: 0, 100, 0, 0. After skipping the
+    // priorless first tick, irate emits 100 then 0 then 0.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 0, 50, 50, 50]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1536,19 +1518,9 @@ fn test_histogram_irate_burst_then_idle_spikes_then_zero() {
 
 #[test]
 fn test_histogram_irate_counter_drop_clamps_to_zero() {
-    // Cumulative per cpu: [0, 10, 5, 15]
-    //   - delta at t=1001: +10 per cpu = 20 collapsed
-    //   - delta at t=1002: cv=5 < pv=10 → loader records an empty
-    //     delta (delta_to_32_or_empty falls back on underflow),
-    //     count is 0
-    //   - delta at t=1003: cv=15, pv=5 → +10 per cpu = 20 collapsed
-    //
-    // irate:
-    //   t=1001: skip (no prior)
-    //   t=1002: count=0 / 1s = 0  (clamp manifests as 0 here — the
-    //                              "negative delta" was absorbed at
-    //                              ingest)
-    //   t=1003: 20 / 1s = 20
+    // cv=5 < pv=10 at t=1002 → delta_to_32_or_empty absorbs the
+    // underflow into an empty delta, so irate emits 0 (not a
+    // negative rate). t=1003 recovers with delta=20.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 5, 15]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1575,10 +1547,8 @@ fn test_histogram_irate_counter_drop_clamps_to_zero() {
 
 #[test]
 fn test_histogram_irate_first_step_is_null() {
-    // Only two cumulative snapshots → loader produces one delta
-    // (at t=1001). irate has no prior for that delta → empty result
-    // → MetricNotFound (the engine surfaces an empty matrix as
-    // MetricNotFound for parity with the other histogram_* helpers).
+    // Single delta → no prior tick to rate against → empty matrix,
+    // which the histogram_* helpers surface as MetricNotFound.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 5]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1591,8 +1561,7 @@ fn test_histogram_irate_first_step_is_null() {
 
 #[test]
 fn test_histogram_irate_label_filter_selects_single_series() {
-    // Same fixture as the steady-rate test but filtered to cpu=0,
-    // so the per-tick count is 10 (single cpu) and rate is 10.
+    // Filter to one cpu → per-tick count is 10 (not 20) → rate 10.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1617,12 +1586,8 @@ fn test_histogram_irate_label_filter_selects_single_series() {
 
 #[test]
 fn test_histogram_irate_composes_inside_sum_and_sum_by() {
-    // Both forms should evaluate to the same single-series result as
-    // the bare histogram_irate call, since the function already
-    // collapses every matching input series into one
-    // `{__name__: metric_name}` output. The outer `sum`/`sum by` is
-    // syntactically present for symmetry with `sum(irate(c[5m]))`
-    // and must parse and execute cleanly.
+    // histogram_irate already collapses to one series, so every
+    // outer sum form must reduce to the same values as the bare call.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1586,8 +1586,7 @@ fn test_histogram_irate_label_filter_selects_single_series() {
 
 #[test]
 fn test_histogram_irate_by_groups_per_cpu() {
-    // Per-cpu deltas of +10/sec → bare call collapses to 20/sec;
-    // `by (cpu)` keeps cpu=0 and cpu=1 separate, each at 10/sec.
+    // Per-cpu deltas of +10/sec; bare call collapses to 20, by(cpu) keeps 10 each.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1622,8 +1621,7 @@ fn test_histogram_irate_by_groups_per_cpu() {
 
 #[test]
 fn test_histogram_irate_without_drops_named_label() {
-    // `without (cpu)` strips cpu, collapsing both series into one
-    // group → same as the bare call (no other labels distinguish them).
+    // cpu is the only label, so `without (cpu)` collapses to one group.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1651,8 +1649,6 @@ fn test_histogram_irate_without_drops_named_label() {
 
 #[test]
 fn test_histogram_count_by_emits_per_group_series() {
-    // bare histogram_count collapses both cpus to one series (10, 14);
-    // by (cpu) emits one series per cpu (5, 7 each).
     let tsdb = Arc::new(create_hist_exec_tsdb());
     let engine = QueryEngine::new(tsdb);
 
@@ -1677,8 +1673,6 @@ fn test_histogram_count_by_emits_per_group_series() {
 
 #[test]
 fn test_histogram_mean_by_preserves_mean_per_group() {
-    // Every observation lands in the bucket for value 10, so each
-    // per-cpu mean should also be 10.
     let tsdb = Arc::new(create_hist_exec_tsdb());
     let engine = QueryEngine::new(tsdb);
 

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1585,29 +1585,54 @@ fn test_histogram_irate_label_filter_selects_single_series() {
 }
 
 #[test]
-fn test_histogram_irate_composes_inside_sum_and_sum_by() {
-    // histogram_irate already collapses to one series, so every
-    // outer sum form must reduce to the same values as the bare call.
+fn test_histogram_irate_by_groups_per_cpu() {
+    // Per-cpu deltas of +10/sec → bare call collapses to 20/sec;
+    // `by (cpu)` keeps cpu=0 and cpu=1 separate, each at 10/sec.
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range(
+            "histogram_irate by (cpu) (req_latency)",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+    let QueryResult::Matrix { mut result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    result.sort_by(|a, b| a.metric.get("cpu").cmp(&b.metric.get("cpu")));
+    assert_eq!(result.len(), 2, "one series per cpu");
+    for series in &result {
+        assert_eq!(
+            series.metric.get("__name__").map(String::as_str),
+            Some("req_latency")
+        );
+        assert!(series.metric.contains_key("cpu"));
+        let values: Vec<f64> = series.values.iter().map(|(_, v)| *v).collect();
+        assert_eq!(values.len(), 3, "first delta is null");
+        for v in values {
+            assert!((v - 10.0).abs() < 1e-9, "expected 10.0 per cpu, got {v}");
+        }
+    }
+    assert_eq!(result[0].metric.get("cpu").map(String::as_str), Some("0"));
+    assert_eq!(result[1].metric.get("cpu").map(String::as_str), Some("1"));
+}
+
+#[test]
+fn test_histogram_irate_without_drops_named_label() {
+    // `without (cpu)` strips cpu, collapsing both series into one
+    // group → same as the bare call (no other labels distinguish them).
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 
     let bare = engine
         .query_range("histogram_irate(req_latency)", 1000.0, 1005.0, 1.0)
         .unwrap();
-    let summed = engine
-        .query_range("sum(histogram_irate(req_latency))", 1000.0, 1005.0, 1.0)
-        .unwrap();
-    let summed_by = engine
+    let without = engine
         .query_range(
-            "sum by (cpu)(histogram_irate(req_latency))",
-            1000.0,
-            1005.0,
-            1.0,
-        )
-        .unwrap();
-    let summed_without = engine
-        .query_range(
-            "sum without (cpu)(histogram_irate(req_latency))",
+            "histogram_irate without (cpu) (req_latency)",
             1000.0,
             1005.0,
             1.0,
@@ -1621,15 +1646,73 @@ fn test_histogram_irate_composes_inside_sum_and_sum_by() {
         assert_eq!(result.len(), 1);
         result[0].values.iter().map(|(_, v)| *v).collect()
     };
+    assert_eq!(values_of(&bare), values_of(&without));
+}
 
-    let bare_v = values_of(&bare);
-    assert_eq!(values_of(&summed), bare_v, "sum is a no-op wrapper");
-    assert_eq!(values_of(&summed_by), bare_v, "sum by (cpu) is a no-op");
-    assert_eq!(
-        values_of(&summed_without),
-        bare_v,
-        "sum without (cpu) is a no-op"
+#[test]
+fn test_histogram_count_by_emits_per_group_series() {
+    // bare histogram_count collapses both cpus to one series (10, 14);
+    // by (cpu) emits one series per cpu (5, 7 each).
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range(
+            "histogram_count by (cpu) (req_latency)",
+            1000.0,
+            1003.0,
+            1.0,
+        )
+        .unwrap();
+    let QueryResult::Matrix { mut result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    result.sort_by(|a, b| a.metric.get("cpu").cmp(&b.metric.get("cpu")));
+    assert_eq!(result.len(), 2);
+    let counts_0: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    let counts_1: Vec<f64> = result[1].values.iter().map(|(_, v)| *v).collect();
+    assert_eq!(counts_0, vec![5.0, 7.0]);
+    assert_eq!(counts_1, vec![5.0, 7.0]);
+}
+
+#[test]
+fn test_histogram_mean_by_preserves_mean_per_group() {
+    // Every observation lands in the bucket for value 10, so each
+    // per-cpu mean should also be 10.
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("histogram_mean by (cpu) (req_latency)", 1000.0, 1003.0, 1.0)
+        .unwrap();
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    assert_eq!(result.len(), 2);
+    for series in &result {
+        for (_, v) in &series.values {
+            assert!((v - 10.0).abs() < 1e-9);
+        }
+    }
+}
+
+#[test]
+fn test_histogram_irate_rejects_invalid_label_in_grouping() {
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine.query_range(
+        r#"histogram_irate by ("cpu") (req_latency)"#,
+        1000.0,
+        1003.0,
+        1.0,
     );
+    match result {
+        Err(QueryError::ParseError(msg)) => {
+            assert!(msg.contains("invalid label name"), "got: {msg}");
+        }
+        other => panic!("expected ParseError, got {other:?}"),
+    }
 }
 
 #[test]
@@ -1653,6 +1736,22 @@ fn test_columns_histogram_irate_resolves_buckets_column() {
 
     let cols = engine
         .columns("histogram_irate(tcp_packet_latency)")
+        .unwrap();
+    assert_eq!(
+        cols,
+        ["tcp_packet_latency:buckets".to_string()]
+            .into_iter()
+            .collect()
+    );
+}
+
+#[test]
+fn test_columns_resolves_histogram_with_by_grouping() {
+    let tsdb = Arc::new(create_columns_histogram_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let cols = engine
+        .columns("histogram_irate by (cpu) (tcp_packet_latency)")
         .unwrap();
     assert_eq!(
         cols,

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1423,6 +1423,280 @@ fn test_histogram_mean_metric_not_found() {
     }
 }
 
+/// Build a TSDB where every snapshot increments the cumulative count
+/// by a fixed `step_increment` per second. Returns the tsdb plus the
+/// expected per-cpu count delta (across both CPUs, summed) that
+/// `histogram_irate` should see per tick.
+///
+/// All observations land in the exact bucket for value 10 (values
+/// < 32 are exact under grouping_power 4), matching the rest of the
+/// histogram exec fixtures.
+fn create_hist_irate_tsdb(cumulative_per_cpu: &[u64]) -> Tsdb {
+    use histogram::Histogram;
+    use metriken_exposition::{Histogram as SnapHist, Snapshot, SnapshotV2};
+
+    let mut tsdb = Tsdb::default();
+    let base_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+
+    for (step, &count) in cumulative_per_cpu.iter().enumerate() {
+        let time = base_time + Duration::from_secs(step as u64);
+        let mut histograms = Vec::new();
+        for cpu in ["0", "1"] {
+            let mut h = Histogram::new(4, 16).unwrap();
+            for _ in 0..count {
+                h.increment(10).unwrap();
+            }
+            let mut meta = HashMap::new();
+            meta.insert("metric".to_string(), "req_latency".to_string());
+            meta.insert("cpu".to_string(), cpu.to_string());
+            histograms.push(SnapHist {
+                name: "req_latency".to_string(),
+                value: h,
+                metadata: meta,
+            });
+        }
+        tsdb.ingest(Snapshot::V2(SnapshotV2 {
+            systemtime: time,
+            duration: Duration::from_secs(1),
+            metadata: HashMap::new(),
+            counters: Vec::new(),
+            gauges: Vec::new(),
+            histograms,
+        }));
+    }
+
+    tsdb
+}
+
+#[test]
+fn test_histogram_irate_steady_rate_is_constant() {
+    // Cumulative per cpu: [0, 10, 20, 30, 40] → per-tick deltas of 10
+    // per cpu = 20 per tick collapsed. At a 1s step, rate is 20.0
+    // every tick from the second observed delta onward. The first
+    // delta (t=1001) has no prior, so no point.
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("histogram_irate(req_latency)", 1000.0, 1005.0, 1.0)
+        .unwrap();
+
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    assert_eq!(result.len(), 1, "irate collapses to one __name__ series");
+    assert_eq!(
+        result[0].metric.get("__name__").map(String::as_str),
+        Some("req_latency")
+    );
+
+    let values: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    // Stored deltas land at t=1001..=1004 (the loader drops the
+    // initial cumulative=0 snapshot since it has no predecessor).
+    // The first delta tick (t=1001) has no prior, so it's skipped;
+    // the remaining three emit a constant rate of 20 events/sec.
+    assert_eq!(values.len(), 3, "first observed delta yields null");
+    for v in values {
+        assert!(
+            (v - 20.0).abs() < 1e-9,
+            "steady rate should be 20.0, got {v}"
+        );
+    }
+}
+
+#[test]
+fn test_histogram_irate_burst_then_idle_spikes_then_zero() {
+    // Cumulative per cpu: [0, 0, 50, 50, 50]
+    //   - delta at t=1001: 0 (loader stores explicit empty)
+    //   - delta at t=1002: 50 (burst)
+    //   - delta at t=1003: 0 (idle)
+    //   - delta at t=1004: 0 (idle)
+    // Summed across both cpus that's 0, 100, 0, 0.
+    //
+    // irate skips t=1001 (no prior), then:
+    //   t=1002: 100 / 1s = 100  (spike)
+    //   t=1003:   0 / 1s = 0    (idle)
+    //   t=1004:   0 / 1s = 0    (idle)
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 0, 50, 50, 50]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("histogram_irate(req_latency)", 1000.0, 1005.0, 1.0)
+        .unwrap();
+
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    let values: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    assert_eq!(values.len(), 3);
+    assert!((values[0] - 100.0).abs() < 1e-9, "spike, got {}", values[0]);
+    assert_eq!(values[1], 0.0, "idle window emits zero rate");
+    assert_eq!(values[2], 0.0, "idle window emits zero rate");
+}
+
+#[test]
+fn test_histogram_irate_counter_drop_clamps_to_zero() {
+    // Cumulative per cpu: [0, 10, 5, 15]
+    //   - delta at t=1001: +10 per cpu = 20 collapsed
+    //   - delta at t=1002: cv=5 < pv=10 → loader records an empty
+    //     delta (delta_to_32_or_empty falls back on underflow),
+    //     count is 0
+    //   - delta at t=1003: cv=15, pv=5 → +10 per cpu = 20 collapsed
+    //
+    // irate:
+    //   t=1001: skip (no prior)
+    //   t=1002: count=0 / 1s = 0  (clamp manifests as 0 here — the
+    //                              "negative delta" was absorbed at
+    //                              ingest)
+    //   t=1003: 20 / 1s = 20
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 5, 15]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("histogram_irate(req_latency)", 1000.0, 1004.0, 1.0)
+        .unwrap();
+
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    let values: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    assert_eq!(values.len(), 2);
+    assert_eq!(
+        values[0], 0.0,
+        "drop in cumulative count clamps to zero, got {}",
+        values[0]
+    );
+    assert!(
+        (values[1] - 20.0).abs() < 1e-9,
+        "recovery after drop, got {}",
+        values[1]
+    );
+}
+
+#[test]
+fn test_histogram_irate_first_step_is_null() {
+    // Only two cumulative snapshots → loader produces one delta
+    // (at t=1001). irate has no prior for that delta → empty result
+    // → MetricNotFound (the engine surfaces an empty matrix as
+    // MetricNotFound for parity with the other histogram_* helpers).
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 5]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine.query_range("histogram_irate(req_latency)", 1000.0, 1002.0, 1.0);
+    match result {
+        Err(QueryError::MetricNotFound(_)) => {}
+        other => panic!("expected MetricNotFound (single delta → null), got {other:?}"),
+    }
+}
+
+#[test]
+fn test_histogram_irate_label_filter_selects_single_series() {
+    // Same fixture as the steady-rate test but filtered to cpu=0,
+    // so the per-tick count is 10 (single cpu) and rate is 10.
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range(
+            r#"histogram_irate(req_latency{cpu="0"})"#,
+            1000.0,
+            1004.0,
+            1.0,
+        )
+        .unwrap();
+
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    let values: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    assert_eq!(values.len(), 2);
+    for v in values {
+        assert!((v - 10.0).abs() < 1e-9, "expected 10.0, got {v}");
+    }
+}
+
+#[test]
+fn test_histogram_irate_composes_inside_sum_and_sum_by() {
+    // Both forms should evaluate to the same single-series result as
+    // the bare histogram_irate call, since the function already
+    // collapses every matching input series into one
+    // `{__name__: metric_name}` output. The outer `sum`/`sum by` is
+    // syntactically present for symmetry with `sum(irate(c[5m]))`
+    // and must parse and execute cleanly.
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let bare = engine
+        .query_range("histogram_irate(req_latency)", 1000.0, 1005.0, 1.0)
+        .unwrap();
+    let summed = engine
+        .query_range("sum(histogram_irate(req_latency))", 1000.0, 1005.0, 1.0)
+        .unwrap();
+    let summed_by = engine
+        .query_range(
+            "sum by (cpu)(histogram_irate(req_latency))",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+    let summed_without = engine
+        .query_range(
+            "sum without (cpu)(histogram_irate(req_latency))",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+
+    let values_of = |r: &QueryResult| -> Vec<f64> {
+        let QueryResult::Matrix { result } = r else {
+            panic!("expected Matrix");
+        };
+        assert_eq!(result.len(), 1);
+        result[0].values.iter().map(|(_, v)| *v).collect()
+    };
+
+    let bare_v = values_of(&bare);
+    assert_eq!(values_of(&summed), bare_v, "sum is a no-op wrapper");
+    assert_eq!(values_of(&summed_by), bare_v, "sum by (cpu) is a no-op");
+    assert_eq!(
+        values_of(&summed_without),
+        bare_v,
+        "sum without (cpu) is a no-op"
+    );
+}
+
+#[test]
+fn test_histogram_irate_rejects_stride_argument() {
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20]));
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine.query_range("histogram_irate(req_latency, 5)", 1000.0, 1003.0, 1.0);
+    match result {
+        Err(QueryError::ParseError(msg)) => {
+            assert!(msg.contains("stride") || msg.contains("window"));
+        }
+        other => panic!("expected ParseError, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_columns_histogram_irate_resolves_buckets_column() {
+    let tsdb = Arc::new(create_columns_histogram_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let cols = engine
+        .columns("histogram_irate(tcp_packet_latency)")
+        .unwrap();
+    assert_eq!(
+        cols,
+        ["tcp_packet_latency:buckets".to_string()]
+            .into_iter()
+            .collect()
+    );
+}
+
 #[test]
 fn test_columns_returns_parse_error_for_invalid_syntax() {
     let tsdb = Arc::new(create_columns_tsdb());


### PR DESCRIPTION
## Summary

Adds `histogram_irate(m)` and extends all three rezolus histogram reducers — `histogram_irate`, `histogram_count`, `histogram_mean` — with an optional PromQL-style aggregation modifier:

```promql
histogram_irate(m)                              # collapse all → one series
histogram_irate by (cpu) (m)                    # one rate per cpu
histogram_mean by (source) (m)                  # one mean per source
histogram_count without (cpu) (m, 15)           # 15s stride, drop cpu label
```

### `histogram_irate` rationale

The 0.10.5 release added `histogram_count(m)` and suggested the idiom `sum(irate(histogram_count(m)[5m]))` to get a per-event rate. That idiom never parses — PromQL disallows range vectors on function-call results, so the rezolus dashboard can't actually use it to derive an event-rate line for histograms with no standalone counter (`scheduler_runqueue_latency`, `scheduler_offcpu`, `scheduler_running`, `tcp_packet_latency`).

`histogram_irate(m)` returns an instant vector directly with no window argument, sidesteps the grammar problem, and gives those dashboards a working fallback rate.

**Semantics**

- First step (no prior sample) → no point emitted.
- Empty / idle window → emits `0` (rate is well-defined zero; differs from `histogram_mean`, which is null on empty).
- Cumulative-count drop (lock-free snapshot undercount) is absorbed at ingest into an empty delta, so the irate value falls out as `0` naturally; the function also includes a defensive `.max(0.0)` clamp.

### `by` / `without` grouping rationale

Today `histogram_count` and `histogram_mean` collapse every matching series into a single output. For "mean value per source, where each source provides one histogram" you'd have to issue N filtered queries. Same applies to `histogram_irate`.

Adding the aggregation-modifier clause means one query returns one series per distinct projected-label tuple. Bare form still collapses (today's behaviour), so this is purely additive.

This also replaces an earlier `sum(histogram_irate(m))` strip shim (commit `6e54f64`, since removed) — the strip was only needed for the dashboard idiom that wrote `sum(...)` for symmetry with `sum(irate(c[5m]))`. With native grouping, that wrapper is no longer necessary; dashboards should drop the `sum(...)` since the bare call has identical semantics.

### Implementation notes

- Reuses `streaming::aggregate::derive_group_labels` for the label projection (promoted to `pub(crate)`).
- Per-group state in the streaming reducers: G accumulator slots (`BTreeMap<u32, u64>` for `count`/`mean`'s bucket-merge path; scalar `u64` counters for `irate`'s no-merge path). Peak memory grows with group count but stays independent of input series cardinality.
- Linear-scan group lookup (`assign_group_index`) — G is small enough that a `HashMap` would be net slower.
- Pre-parser in `query_range` accepts `<func> [by (..) | without (..)] (body)`; `columns()` resolver mirrors the same surface.

### Limitation (unchanged from the existing histogram_* functions)

promql-parser doesn't know any of these names, so they only work at the top of a query. Expressions like `histogram_irate(a) + histogram_irate(b)` still don't parse; same restriction `histogram_count` / `histogram_mean` / `histogram_quantiles` already have.

Bumps `metriken-query` to 0.10.6.

## Test plan

- [x] `histogram_irate` — steady rate, burst→idle, counter-drop clamp, first-step null, label filter, stride rejection
- [x] `by (cpu)` — `histogram_irate`, `histogram_count`, `histogram_mean` each emit one series per cpu
- [x] `without (cpu)` — collapses to a single group (cpu is the only label)
- [x] Grouping rejects non-identifier label names
- [x] `columns()` resolver handles `histogram_irate by (cpu) (m)`
- [x] 79 unit tests pass (was 74)
- [x] `cargo clippy --tests` clean, `cargo fmt --check` clean

https://claude.ai/code/session_0129HzerQVUDQfKPKjdUSMWn