### PR TITLE
fix(query): allow sum() to wrap histogram_irate/_mean/_count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -143,31 +143,25 @@ impl HistogramGroupBy {
     }
 }
 
-/// Detect `sum [by/without (...)] (<histogram_func>(...))` and rewrite
-/// to the native `<histogram_func> [by/without (...)] (...)` form.
+/// Rewrite `sum [by/without (...)] (<histogram_func>(...))` to the
+/// native `<histogram_func> [by/without (...)] (...)` form.
 ///
-/// `histogram_irate`/`histogram_mean`/`histogram_count` aren't standard
-/// PromQL function names, so the promql-parser crate rejects them
-/// outright — even when wrapped in a standard aggregator.  Rather than
-/// teach the parser these names, the wrapping `sum` is unwrapped at
-/// the string level here and passed through the existing top-level
-/// dispatcher.  Returns `None` if the input doesn't match the pattern.
-///
-/// Restricted to `sum` because the internal histogram grouping already
-/// reduces across label sets via `total_count` / mean / per-step rate;
-/// `sum` is therefore a pass-through.  Other aggregators (`avg`, `min`,
-/// `max`, `count`) would require post-pipeline reduction over the
-/// per-group output and are intentionally left untouched.
+/// `histogram_irate`/`histogram_mean` aren't standard PromQL names, so
+/// promql-parser rejects them — even wrapped in a known aggregator —
+/// before the engine sees the query. The wrapping `sum` is a
+/// pass-through against the histogram pipeline's internal grouping
+/// (already collapses across label sets), so unwrapping here lets the
+/// existing top-level dispatcher take over. `avg`/`min`/`max` would
+/// need per-group post-reduction and are intentionally left alone.
 fn unwrap_sum_around_histogram(query: &str) -> Option<String> {
     let query = query.trim();
     let after_sum = query.strip_prefix("sum")?;
-    // Guard against names with `sum` as a prefix (e.g. `summary_foo`).
+    // Reject identifier prefixes like `summary_foo`.
     if !matches!(after_sum.chars().next(), Some('(' | ' ' | '\t')) {
         return None;
     }
     let rest = after_sum.trim_start();
 
-    // Outer aggregation modifier on the wrapping `sum`.
     let (grouping_clause, after_modifier) = if let Some(r) = rest.strip_prefix("by") {
         let (after, clause) = take_grouping_clause(r.trim_start(), "by")?;
         (Some(clause), after)
@@ -178,20 +172,21 @@ fn unwrap_sum_around_histogram(query: &str) -> Option<String> {
         (None, rest)
     };
 
-    // Body of the outer `sum`: must be `(<inner>)` with balanced parens.
     let after_open = after_modifier.strip_prefix('(')?;
     let close = find_close_paren(after_open)?;
+    // Anything after the closing paren means the `sum` is part of a
+    // larger expression (binary op, another wrapper) we can't safely
+    // rewrite from string level.
     if after_open[close + 1..]
         .trim_start()
         .chars()
         .next()
         .is_some()
     {
-        return None; // trailing tokens — not the shape we rewrite.
+        return None;
     }
     let inner = after_open[..close].trim();
 
-    // Inner must be exactly one of the histogram_* function calls.
     let inner_func = ["histogram_irate", "histogram_mean", "histogram_count"]
         .iter()
         .find(|f| inner.starts_with(*f))?;
@@ -200,9 +195,8 @@ fn unwrap_sum_around_histogram(query: &str) -> Option<String> {
         return None;
     }
 
-    // Refuse to rewrite if the inner call already carries its own
-    // grouping modifier — combining two would be ambiguous and the
-    // existing dispatcher rejects it for the same reason.
+    // Two grouping modifiers would be ambiguous; bail and let the
+    // dispatcher emit its own error.
     let inner_after_name = after_name.trim_start();
     if inner_after_name.starts_with("by") || inner_after_name.starts_with("without") {
         let next = inner_after_name
@@ -220,10 +214,8 @@ fn unwrap_sum_around_histogram(query: &str) -> Option<String> {
     }
 }
 
-/// Consume a `by (..)` / `without (..)` clause from the start of `s`,
-/// returning `(rest_after_clause, "by (..)" | "without (..)")`.  The
-/// returned clause string keeps the keyword so callers can splice it
-/// directly into a rewritten query.
+/// Consume a `by (..)` / `without (..)` clause, returning the rest of
+/// the input and the clause re-stringified so callers can splice it.
 fn take_grouping_clause<'a>(s: &'a str, keyword: &str) -> Option<(&'a str, String)> {
     let inside = s.strip_prefix('(')?;
     let close = find_close_paren(inside)?;
@@ -700,15 +692,9 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
             return self.handle_histogram_heatmap(query_str, start, end);
         }
 
-        // Recognise `sum [by/without (...)] (<histogram_func>(...))` and
-        // rewrite to the native grouped form before the histogram
-        // dispatchers below match.  `sum` is the only aggregator with a
-        // direct native equivalent — `histogram_irate`/`mean`/`count`
-        // already collapse across label sets in their internal grouping
-        // pass, so `sum [grouping] (...)` is semantically identical to
-        // `<func> [grouping] (...)`.  Other aggregators (`avg`, `min`,
-        // `max`, `count`) would require post-pipeline reduction and are
-        // not rewritten here.
+        // Unwrap `sum [by/without (...)] (<histogram_func>(...))` —
+        // promql-parser doesn't know our `histogram_irate`/`mean`
+        // names, so wrapped forms would otherwise fail at parse time.
         let rewritten = unwrap_sum_around_histogram(query_str);
         let query_str: &str = rewritten.as_deref().unwrap_or(query_str);
 

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -143,6 +143,95 @@ impl HistogramGroupBy {
     }
 }
 
+/// Detect `sum [by/without (...)] (<histogram_func>(...))` and rewrite
+/// to the native `<histogram_func> [by/without (...)] (...)` form.
+///
+/// `histogram_irate`/`histogram_mean`/`histogram_count` aren't standard
+/// PromQL function names, so the promql-parser crate rejects them
+/// outright — even when wrapped in a standard aggregator.  Rather than
+/// teach the parser these names, the wrapping `sum` is unwrapped at
+/// the string level here and passed through the existing top-level
+/// dispatcher.  Returns `None` if the input doesn't match the pattern.
+///
+/// Restricted to `sum` because the internal histogram grouping already
+/// reduces across label sets via `total_count` / mean / per-step rate;
+/// `sum` is therefore a pass-through.  Other aggregators (`avg`, `min`,
+/// `max`, `count`) would require post-pipeline reduction over the
+/// per-group output and are intentionally left untouched.
+fn unwrap_sum_around_histogram(query: &str) -> Option<String> {
+    let query = query.trim();
+    let after_sum = query.strip_prefix("sum")?;
+    // Guard against names with `sum` as a prefix (e.g. `summary_foo`).
+    if !matches!(after_sum.chars().next(), Some('(' | ' ' | '\t')) {
+        return None;
+    }
+    let rest = after_sum.trim_start();
+
+    // Outer aggregation modifier on the wrapping `sum`.
+    let (grouping_clause, after_modifier) = if let Some(r) = rest.strip_prefix("by") {
+        let (after, clause) = take_grouping_clause(r.trim_start(), "by")?;
+        (Some(clause), after)
+    } else if let Some(r) = rest.strip_prefix("without") {
+        let (after, clause) = take_grouping_clause(r.trim_start(), "without")?;
+        (Some(clause), after)
+    } else {
+        (None, rest)
+    };
+
+    // Body of the outer `sum`: must be `(<inner>)` with balanced parens.
+    let after_open = after_modifier.strip_prefix('(')?;
+    let close = find_close_paren(after_open)?;
+    if after_open[close + 1..]
+        .trim_start()
+        .chars()
+        .next()
+        .is_some()
+    {
+        return None; // trailing tokens — not the shape we rewrite.
+    }
+    let inner = after_open[..close].trim();
+
+    // Inner must be exactly one of the histogram_* function calls.
+    let inner_func = ["histogram_irate", "histogram_mean", "histogram_count"]
+        .iter()
+        .find(|f| inner.starts_with(*f))?;
+    let after_name = inner.strip_prefix(*inner_func)?;
+    if !matches!(after_name.chars().next(), Some('(' | ' ' | '\t')) {
+        return None;
+    }
+
+    // Refuse to rewrite if the inner call already carries its own
+    // grouping modifier — combining two would be ambiguous and the
+    // existing dispatcher rejects it for the same reason.
+    let inner_after_name = after_name.trim_start();
+    if inner_after_name.starts_with("by") || inner_after_name.starts_with("without") {
+        let next = inner_after_name
+            .chars()
+            .nth("by".len().max("without".len()))
+            .unwrap_or(' ');
+        if matches!(next, '(' | ' ' | '\t') {
+            return None;
+        }
+    }
+
+    match grouping_clause {
+        Some(clause) => Some(format!("{inner_func} {clause} {inner_after_name}")),
+        None => Some(inner.to_string()),
+    }
+}
+
+/// Consume a `by (..)` / `without (..)` clause from the start of `s`,
+/// returning `(rest_after_clause, "by (..)" | "without (..)")`.  The
+/// returned clause string keeps the keyword so callers can splice it
+/// directly into a rewritten query.
+fn take_grouping_clause<'a>(s: &'a str, keyword: &str) -> Option<(&'a str, String)> {
+    let inside = s.strip_prefix('(')?;
+    let close = find_close_paren(inside)?;
+    let labels = &inside[..close];
+    let after = inside[close + 1..].trim_start();
+    Some((after, format!("{keyword} ({labels})")))
+}
+
 /// Parse `<func> [by (labels) | without (labels)] (body)`. `Ok(None)`
 /// if the prefix doesn't match.
 pub(crate) fn parse_histogram_call<'a>(
@@ -610,6 +699,18 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         if query_str.starts_with("histogram_heatmap(") && query_str.ends_with(")") {
             return self.handle_histogram_heatmap(query_str, start, end);
         }
+
+        // Recognise `sum [by/without (...)] (<histogram_func>(...))` and
+        // rewrite to the native grouped form before the histogram
+        // dispatchers below match.  `sum` is the only aggregator with a
+        // direct native equivalent — `histogram_irate`/`mean`/`count`
+        // already collapse across label sets in their internal grouping
+        // pass, so `sum [grouping] (...)` is semantically identical to
+        // `<func> [grouping] (...)`.  Other aggregators (`avg`, `min`,
+        // `max`, `count`) would require post-pipeline reduction and are
+        // not rewritten here.
+        let rewritten = unwrap_sum_around_histogram(query_str);
+        let query_str: &str = rewritten.as_deref().unwrap_or(query_str);
 
         for func in ["histogram_mean", "histogram_count"] {
             if let Some((inner, group_by)) = parse_histogram_call(func, query_str)? {

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1710,6 +1710,195 @@ fn test_histogram_irate_rejects_invalid_label_in_grouping() {
 }
 
 #[test]
+fn test_sum_wrapping_histogram_irate_matches_bare() {
+    // sum(histogram_irate(m)) is semantically identical to the bare
+    // call: both collapse across all label sets into one series.
+    // This is the contract the rezolus dashboards rely on.
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let bare = engine
+        .query_range("histogram_irate(req_latency)", 1000.0, 1005.0, 1.0)
+        .unwrap();
+    let wrapped = engine
+        .query_range("sum(histogram_irate(req_latency))", 1000.0, 1005.0, 1.0)
+        .unwrap();
+
+    let values_of = |r: &QueryResult| -> Vec<f64> {
+        let QueryResult::Matrix { result } = r else {
+            panic!("expected Matrix");
+        };
+        assert_eq!(result.len(), 1);
+        result[0].values.iter().map(|(_, v)| *v).collect()
+    };
+    assert_eq!(values_of(&bare), values_of(&wrapped));
+}
+
+#[test]
+fn test_sum_by_wrapping_histogram_irate_matches_native_grouping() {
+    // sum by (cpu) (histogram_irate(m)) ≡ histogram_irate by (cpu) (m).
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let native = engine
+        .query_range(
+            "histogram_irate by (cpu) (req_latency)",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+    let wrapped = engine
+        .query_range(
+            "sum by (cpu) (histogram_irate(req_latency))",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+
+    let sorted_pairs = |r: QueryResult| -> Vec<(String, Vec<f64>)> {
+        let QueryResult::Matrix { mut result } = r else {
+            panic!("expected Matrix");
+        };
+        result.sort_by(|a, b| a.metric.get("cpu").cmp(&b.metric.get("cpu")));
+        result
+            .into_iter()
+            .map(|s| {
+                (
+                    s.metric.get("cpu").cloned().unwrap_or_default(),
+                    s.values.iter().map(|(_, v)| *v).collect(),
+                )
+            })
+            .collect()
+    };
+    assert_eq!(sorted_pairs(native), sorted_pairs(wrapped));
+}
+
+#[test]
+fn test_sum_without_wrapping_histogram_irate_matches_native_grouping() {
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let native = engine
+        .query_range(
+            "histogram_irate without (cpu) (req_latency)",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+    let wrapped = engine
+        .query_range(
+            "sum without (cpu) (histogram_irate(req_latency))",
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+
+    let values_of = |r: QueryResult| -> Vec<f64> {
+        let QueryResult::Matrix { result } = r else {
+            panic!("expected Matrix");
+        };
+        assert_eq!(result.len(), 1);
+        result[0].values.iter().map(|(_, v)| *v).collect()
+    };
+    assert_eq!(values_of(native), values_of(wrapped));
+}
+
+#[test]
+fn test_sum_wrapping_histogram_count_matches_bare() {
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let bare = engine
+        .query_range("histogram_count(req_latency)", 1000.0, 1003.0, 1.0)
+        .unwrap();
+    let wrapped = engine
+        .query_range("sum(histogram_count(req_latency))", 1000.0, 1003.0, 1.0)
+        .unwrap();
+
+    let values_of = |r: QueryResult| -> Vec<f64> {
+        let QueryResult::Matrix { result } = r else {
+            panic!("expected Matrix");
+        };
+        assert_eq!(result.len(), 1);
+        result[0].values.iter().map(|(_, v)| *v).collect()
+    };
+    assert_eq!(values_of(bare), values_of(wrapped));
+}
+
+#[test]
+fn test_sum_by_wrapping_histogram_mean_matches_native_grouping() {
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let native = engine
+        .query_range("histogram_mean by (cpu) (req_latency)", 1000.0, 1003.0, 1.0)
+        .unwrap();
+    let wrapped = engine
+        .query_range(
+            "sum by (cpu) (histogram_mean(req_latency))",
+            1000.0,
+            1003.0,
+            1.0,
+        )
+        .unwrap();
+
+    let sorted_pairs = |r: QueryResult| -> Vec<(String, Vec<f64>)> {
+        let QueryResult::Matrix { mut result } = r else {
+            panic!("expected Matrix");
+        };
+        result.sort_by(|a, b| a.metric.get("cpu").cmp(&b.metric.get("cpu")));
+        result
+            .into_iter()
+            .map(|s| {
+                (
+                    s.metric.get("cpu").cloned().unwrap_or_default(),
+                    s.values.iter().map(|(_, v)| *v).collect(),
+                )
+            })
+            .collect()
+    };
+    assert_eq!(sorted_pairs(native), sorted_pairs(wrapped));
+}
+
+#[test]
+fn test_sum_wrapping_histogram_irate_with_label_matcher() {
+    // Label matcher braces inside the inner selector must not confuse
+    // the string-level rewriter.
+    let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
+    let engine = QueryEngine::new(tsdb);
+
+    let bare = engine
+        .query_range(
+            r#"histogram_irate(req_latency{cpu="0"})"#,
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+    let wrapped = engine
+        .query_range(
+            r#"sum(histogram_irate(req_latency{cpu="0"}))"#,
+            1000.0,
+            1005.0,
+            1.0,
+        )
+        .unwrap();
+
+    let values_of = |r: &QueryResult| -> Vec<f64> {
+        let QueryResult::Matrix { result } = r else {
+            panic!("expected Matrix");
+        };
+        assert_eq!(result.len(), 1);
+        result[0].values.iter().map(|(_, v)| *v).collect()
+    };
+    assert_eq!(values_of(&bare), values_of(&wrapped));
+}
+
+#[test]
 fn test_histogram_irate_rejects_stride_argument() {
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20]));
     let engine = QueryEngine::new(tsdb);

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1711,9 +1711,8 @@ fn test_histogram_irate_rejects_invalid_label_in_grouping() {
 
 #[test]
 fn test_sum_wrapping_histogram_irate_matches_bare() {
-    // sum(histogram_irate(m)) is semantically identical to the bare
-    // call: both collapse across all label sets into one series.
-    // This is the contract the rezolus dashboards rely on.
+    // The rezolus 0.10.6 dashboard contract: sum(histogram_irate(m))
+    // must compose, not just parse.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1736,7 +1735,6 @@ fn test_sum_wrapping_histogram_irate_matches_bare() {
 
 #[test]
 fn test_sum_by_wrapping_histogram_irate_matches_native_grouping() {
-    // sum by (cpu) (histogram_irate(m)) ≡ histogram_irate by (cpu) (m).
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 
@@ -1866,8 +1864,7 @@ fn test_sum_by_wrapping_histogram_mean_matches_native_grouping() {
 
 #[test]
 fn test_sum_wrapping_histogram_irate_with_label_matcher() {
-    // Label matcher braces inside the inner selector must not confuse
-    // the string-level rewriter.
+    // Guards the string-level rewriter against `{}` in the inner selector.
     let tsdb = Arc::new(create_hist_irate_tsdb(&[0, 10, 20, 30, 40]));
     let engine = QueryEngine::new(tsdb);
 


### PR DESCRIPTION
## Summary

Fixes the issue where `sum(histogram_irate(<selector>))` — the dashboard contract introduced in 0.10.6 — fails to parse with `"unknown function with name 'histogram_irate'"`. Same applies to `sum(histogram_mean(...))` and `sum(histogram_count(...))`.

Root cause: the promql-parser crate doesn't know about our custom `histogram_irate` / `histogram_mean` names, so any expression that wraps them in a standard aggregator gets rejected at parse time, before the engine's dispatcher sees the query.

Fix: pre-rewrite `sum [by/without (...)] (<histogram_func>(...))` at the string level inside `query_range`, before either dispatcher runs. The wrapping `sum` is a no-op against the histogram pipeline's internal grouping pass, so the rewrite collapses to the native `<histogram_func> [by/without (...)] (...)` form already handled by the existing top-level dispatcher.

Restricted to `sum`: the internal grouping in `histogram_irate` / `mean` / `count` already reduces across label sets, making `sum` a pass-through. `avg`/`min`/`max` would require post-pipeline reduction and are intentionally left untouched (separate change).

Bumps `metriken-query` to **0.10.7**.

## Test plan

- [x] `cargo test --workspace` — all 84 metriken-query tests pass
- [x] Six new TDD tests covering `sum(histogram_irate(...))`, `sum by (cpu) (histogram_irate(...))`, `sum without (cpu) (histogram_irate(...))`, `sum(histogram_count(...))`, `sum by (cpu) (histogram_mean(...))`, and label-matcher-inside-selector
- [x] `cargo fmt`, `cargo clippy -p metriken-query --all-features` clean (one pre-existing unrelated warning in `tsdb/mod.rs`)
- [ ] Validate against rezolus viewer with `query=sum(histogram_irate(scheduler_runqueue_latency))`

## Out of scope

- `avg`/`min`/`max`/`count` wrapping `histogram_*` — these require per-label-set output from the histogram pipeline.
- Binary expressions involving `histogram_*` — same constraint.
- The "multi-source parquet returns Metric not found" observation in the bug report — a separate issue once the boundary is pinned down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)