### PR TITLE
(draft) DuckDB as the TSDB data path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +56,21 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
@@ -78,7 +110,7 @@ version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -117,6 +149,7 @@ dependencies = [
  "atoi",
  "base64",
  "chrono",
+ "comfy-table",
  "half",
  "lexical-core",
  "num-traits",
@@ -181,6 +214,9 @@ name = "arrow-schema"
 version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "arrow-select"
@@ -188,7 +224,7 @@ version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -223,6 +259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,10 +292,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -274,6 +374,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +396,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cfgrammar"
@@ -320,6 +432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +469,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +515,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "duckdb"
+version = "1.10503.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,8 +567,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -409,6 +615,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,10 +638,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -439,7 +693,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -460,8 +717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -471,9 +730,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -509,6 +770,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -521,6 +791,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -536,6 +815,104 @@ checksum = "78dbc692bf02314a491f06bb95ae039fe842c1e1179f0036df08800fba0fb29b"
 dependencies = [
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -563,10 +940,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -585,6 +1065,12 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
@@ -690,6 +1176,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10503.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,14 +1215,26 @@ checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -791,6 +1306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4_flex"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +1355,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -858,6 +1379,7 @@ version = "0.10.6"
 dependencies = [
  "arrow",
  "bytes",
+ "duckdb",
  "histogram",
  "metriken-exposition",
  "parquet",
@@ -866,6 +1388,27 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -975,7 +1518,7 @@ version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d7efd3052f7d6ef601085559a246bc991e9a8cc77e02753737df6322ce35f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1003,6 +1546,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -1035,7 +1584,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1060,10 +1609,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1072,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1108,6 +1675,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1769,71 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1167,6 +1874,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,12 +1985,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1203,8 +2038,43 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1224,6 +2094,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -1264,7 +2140,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1290,10 +2166,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -1314,6 +2214,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sparsevec"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,10 +2236,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1340,6 +2294,43 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1357,8 +2348,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1387,7 +2378,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1444,6 +2435,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +2535,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "trybuild"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +2632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +2648,46 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -1558,6 +2714,15 @@ checksum = "bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1593,8 +2758,19 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1616,7 +2792,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1664,13 +2840,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1693,7 +2920,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1704,7 +2931,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1733,12 +2960,168 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1785,7 +3168,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1801,7 +3184,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1844,6 +3227,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,14 +3291,106 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2470,7 +2471,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3"
+tokio = "1"

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -14,16 +14,15 @@ repository = "https://github.com/iopsystems/metriken"
 [dependencies]
 arrow.workspace = true
 bytes = "1"
+duckdb = { version = "1.10503.1", features = ["bundled"] }
 histogram.workspace = true
 metriken-exposition = { version = "0.16.1", path = "../metriken-exposition", default-features = false, optional = true }
 parquet = { workspace = true, features = ["arrow", "zstd"] }
 promql-parser = "0.8"
 serde.workspace = true
 serde_json.workspace = true
-thiserror = "2"
-
-[dev-dependencies]
 tempfile.workspace = true
+thiserror = "2"
 
 [features]
 default = ["ingest", "lz4"]

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 thiserror = "2"
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["ingest", "lz4"]

--- a/metriken-query/examples/cachecannon_mem.rs
+++ b/metriken-query/examples/cachecannon_mem.rs
@@ -179,7 +179,8 @@ fn measure<F: FnOnce()>(f: F) -> (usize, usize) {
     (peak_delta, allocated)
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let Some(path) = fixture_path() else {
         eprintln!(
             "set CACHECANNON_PARQUET=/path/to/cachecannon.parquet (or check out rezolus \
@@ -190,7 +191,7 @@ fn main() {
 
     println!("loading {path:?}");
     let load = snap();
-    let tsdb = Arc::new(Tsdb::load(&path).expect("load parquet"));
+    let tsdb = Arc::new(Tsdb::load(&path).await.expect("load parquet"));
     let after_load = snap();
     println!(
         "tsdb resident: {} (allocated during load: {})\n",

--- a/metriken-query/src/lib.rs
+++ b/metriken-query/src/lib.rs
@@ -12,14 +12,16 @@
 //! use std::sync::Arc;
 //! use std::path::Path;
 //!
-//! // Load a parquet file
-//! let tsdb = Arc::new(Tsdb::load(Path::new("metrics.parquet")).unwrap());
+//! # async fn run() {
+//! // Load a parquet file (requires a tokio runtime)
+//! let tsdb = Arc::new(Tsdb::load(Path::new("metrics.parquet")).await.unwrap());
 //!
 //! // Create a query engine
 //! let engine = QueryEngine::new(tsdb);
 //!
 //! // Execute a range query
 //! let result = engine.query_range("rate(http_requests[5m])", start, end, step);
+//! # }
 //! ```
 
 pub mod promql;

--- a/metriken-query/src/promql/streaming/tests.rs
+++ b/metriken-query/src/promql/streaming/tests.rs
@@ -387,8 +387,8 @@ fn count_points(result: &QueryResult) -> usize {
 ///
 /// Per-query wall-clock is printed with `--nocapture` so the test
 /// also doubles as a quick perf sanity-check on local dev.
-#[test]
-fn cachecannon_smoke_test() {
+#[tokio::test]
+async fn cachecannon_smoke_test() {
     let Some(path) = cachecannon_parquet_path() else {
         eprintln!(
             "skipping cachecannon smoke test: set CACHECANNON_PARQUET=/path/to/cachecannon.parquet \
@@ -397,7 +397,7 @@ fn cachecannon_smoke_test() {
         return;
     };
 
-    let tsdb = match crate::Tsdb::load(&path) {
+    let tsdb = match crate::Tsdb::load(&path).await {
         Ok(t) => Arc::new(t),
         Err(e) => {
             eprintln!("skipping cachecannon smoke test: failed to load {path:?}: {e}");

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -58,6 +58,20 @@ fn snap_timestamp(ts: u64, interval_ns: u64) -> u64 {
     }
 }
 
+/// Quote a parquet column name for inclusion in a DuckDB SQL statement.
+/// SQL identifiers can't be bound as parameters, so callers building
+/// queries over schema-derived column names must route every name
+/// through here rather than interpolating raw. NUL bytes are rejected
+/// because some SQL parsers treat them as string terminators; every
+/// other character is permitted inside ANSI/DuckDB quoted identifiers as
+/// long as embedded double quotes are doubled.
+fn quote_ident(name: &str) -> Result<String, Box<dyn Error>> {
+    if name.as_bytes().contains(&0) {
+        return Err(format!("column name contains NUL byte: {name:?}").into());
+    }
+    Ok(format!("\"{}\"", name.replace('"', "\"\"")))
+}
+
 #[derive(Default, Clone)]
 pub struct Tsdb {
     sampling_interval_ms: u64,
@@ -240,11 +254,11 @@ impl Tsdb {
                         .entry(labels.clone())
                         .or_default();
 
+                    let col = quote_ident(column_name)?;
                     let sql = format!(
-                        r#"SELECT timestamp, "{col}" FROM read_parquet(?)
-                           WHERE timestamp IS NOT NULL AND "{col}" IS NOT NULL
-                           ORDER BY timestamp"#,
-                        col = column_name.replace('"', "\"\"")
+                        "SELECT timestamp, {col} FROM read_parquet(?) \
+                         WHERE timestamp IS NOT NULL AND {col} IS NOT NULL \
+                         ORDER BY timestamp"
                     );
                     let mut stmt = conn.prepare(&sql)?;
                     let rows = stmt.query_map([&parquet_path], |row| {
@@ -271,11 +285,11 @@ impl Tsdb {
                         .entry(labels.clone())
                         .or_default();
 
+                    let col = quote_ident(column_name)?;
                     let sql = format!(
-                        r#"SELECT timestamp, "{col}" FROM read_parquet(?)
-                           WHERE timestamp IS NOT NULL AND "{col}" IS NOT NULL
-                           ORDER BY timestamp"#,
-                        col = column_name.replace('"', "\"\"")
+                        "SELECT timestamp, {col} FROM read_parquet(?) \
+                         WHERE timestamp IS NOT NULL AND {col} IS NOT NULL \
+                         ORDER BY timestamp"
                     );
                     let mut stmt = conn.prepare(&sql)?;
                     let rows = stmt.query_map([&parquet_path], |row| {
@@ -312,11 +326,11 @@ impl Tsdb {
                     // missing snapshot still produces an explicit empty
                     // delta against `prev` — matches the prior loader and
                     // keeps offset-based timestamp axes aligned.
+                    let col = quote_ident(column_name)?;
                     let sql = format!(
-                        r#"SELECT timestamp, "{col}" FROM read_parquet(?)
-                           WHERE timestamp IS NOT NULL
-                           ORDER BY timestamp"#,
-                        col = column_name.replace('"', "\"\"")
+                        "SELECT timestamp, {col} FROM read_parquet(?) \
+                         WHERE timestamp IS NOT NULL \
+                         ORDER BY timestamp"
                     );
                     let mut stmt = conn.prepare(&sql)?;
                     let rows = stmt.query_map([&parquet_path], |row| {

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -34,9 +34,10 @@ use series::{delta_to_32_or_empty, empty_delta_32};
 /// Per-column dispatch target precomputed from the parquet schema.
 /// `column_name` is the parquet field name, preserved so callers can map
 /// a resolved series back to its on-disk column without re-parsing the
-/// schema.
+/// schema. Columns that don't map to a fetchable kind (the timestamp
+/// column itself, anything with an unrecognized data type) are dropped
+/// during classification rather than carried as a variant.
 enum ColumnTarget {
-    Skip,
     Counter {
         name: String,
         labels: Labels,
@@ -107,6 +108,7 @@ struct ConnPool {
 
 impl ConnPool {
     fn new(size: usize) -> Result<Self, duckdb::Error> {
+        // In-memory: we run SELECTs against `read_parquet(?)`, no persistent DuckDB tables.
         let conns: Result<Vec<_>, _> = (0..size)
             .map(|_| duckdb::Connection::open_in_memory())
             .collect();
@@ -134,13 +136,33 @@ impl ConnPool {
     }
 }
 
-/// Untyped per-column rows returned from a worker task. Pairs with the
-/// matching `ColumnTarget` so the post-fetch sync pass knows how to
-/// fold each batch into the in-memory series.
-enum RawRows {
-    Counter(Vec<(u64, u64)>),
-    Gauge(Vec<(u64, i64)>),
-    Histogram(Vec<(u64, Option<Vec<u64>>)>),
+/// Result of a single per-column fetch task. Bundles the column's
+/// schema-derived metadata with the rows pulled from DuckDB so the
+/// post-fetch sync pass can fold both into the in-memory series with
+/// an exhaustive match — no risk of pairing a `Counter` target with
+/// `Histogram` rows by accident.
+enum FetchResult {
+    Counter {
+        name: String,
+        labels: Labels,
+        column_name: String,
+        rows: Vec<(u64, u64)>,
+    },
+    Gauge {
+        name: String,
+        labels: Labels,
+        column_name: String,
+        rows: Vec<(u64, i64)>,
+    },
+    Histogram {
+        name: String,
+        labels: Labels,
+        column_name: String,
+        grouping_power: u8,
+        max_value_power: u8,
+        config: Option<::histogram::Config>,
+        rows: Vec<(u64, Option<Vec<u64>>)>,
+    },
 }
 
 fn fetch_counter_column(
@@ -220,38 +242,75 @@ fn fetch_histogram_column(
     Ok(out)
 }
 
+/// Run the appropriate fetch helper for `target` and bundle its rows
+/// with `target`'s metadata into a `FetchResult`. Taking `target` by
+/// value lets us repackage its fields into the result without cloning.
 fn fetch_dispatch(
     conn: &mut duckdb::Connection,
     parquet_path: &str,
-    target: &ColumnTarget,
-) -> Result<RawRows, FetchError> {
+    target: ColumnTarget,
+) -> Result<FetchResult, FetchError> {
     match target {
-        ColumnTarget::Counter { column_name, .. } => {
-            fetch_counter_column(conn, parquet_path, column_name).map(RawRows::Counter)
-        }
-        ColumnTarget::Gauge { column_name, .. } => {
-            fetch_gauge_column(conn, parquet_path, column_name).map(RawRows::Gauge)
-        }
-        ColumnTarget::Histogram { column_name, .. } => {
-            fetch_histogram_column(conn, parquet_path, column_name).map(RawRows::Histogram)
-        }
-        ColumnTarget::Skip => panic!("Skip targets must be filtered out before dispatch"),
-    }
-}
-
-/// Fold one fetched column's raw rows into the in-memory `Tsdb`.
-/// Mirrors the per-arm logic of the old synchronous loader exactly —
-/// only the data source is different.
-fn populate_target(data: &mut Tsdb, target: ColumnTarget, rows: RawRows, interval_ns: u64) {
-    match (target, rows) {
-        (
-            ColumnTarget::Counter {
+        ColumnTarget::Counter {
+            name,
+            labels,
+            column_name,
+        } => {
+            let rows = fetch_counter_column(conn, parquet_path, &column_name)?;
+            Ok(FetchResult::Counter {
                 name,
                 labels,
                 column_name,
-            },
-            RawRows::Counter(rows),
-        ) => {
+                rows,
+            })
+        }
+        ColumnTarget::Gauge {
+            name,
+            labels,
+            column_name,
+        } => {
+            let rows = fetch_gauge_column(conn, parquet_path, &column_name)?;
+            Ok(FetchResult::Gauge {
+                name,
+                labels,
+                column_name,
+                rows,
+            })
+        }
+        ColumnTarget::Histogram {
+            name,
+            labels,
+            column_name,
+            grouping_power,
+            max_value_power,
+            config,
+        } => {
+            let rows = fetch_histogram_column(conn, parquet_path, &column_name)?;
+            Ok(FetchResult::Histogram {
+                name,
+                labels,
+                column_name,
+                grouping_power,
+                max_value_power,
+                config,
+                rows,
+            })
+        }
+    }
+}
+
+/// Fold one fetched column's rows into the in-memory `Tsdb`. The match
+/// is exhaustive over `FetchResult`'s variants by construction — each
+/// variant pairs the target metadata with its matching row type, so
+/// there's no way to land here with a mismatched kind.
+fn apply_fetch_result(data: &mut Tsdb, result: FetchResult, interval_ns: u64) {
+    match result {
+        FetchResult::Counter {
+            name,
+            labels,
+            column_name,
+            rows,
+        } => {
             data.columns
                 .entry(name.clone())
                 .or_default()
@@ -266,14 +325,12 @@ fn populate_target(data: &mut Tsdb, target: ColumnTarget, rows: RawRows, interva
                 series.insert(snap_timestamp(ts_raw, interval_ns), v);
             }
         }
-        (
-            ColumnTarget::Gauge {
-                name,
-                labels,
-                column_name,
-            },
-            RawRows::Gauge(rows),
-        ) => {
+        FetchResult::Gauge {
+            name,
+            labels,
+            column_name,
+            rows,
+        } => {
             data.columns
                 .entry(name.clone())
                 .or_default()
@@ -288,17 +345,15 @@ fn populate_target(data: &mut Tsdb, target: ColumnTarget, rows: RawRows, interva
                 series.insert(snap_timestamp(ts_raw, interval_ns), v);
             }
         }
-        (
-            ColumnTarget::Histogram {
-                name,
-                labels,
-                column_name,
-                grouping_power,
-                max_value_power,
-                config,
-            },
-            RawRows::Histogram(rows),
-        ) => {
+        FetchResult::Histogram {
+            name,
+            labels,
+            column_name,
+            grouping_power,
+            max_value_power,
+            config,
+            rows,
+        } => {
             data.columns
                 .entry(name.clone())
                 .or_default()
@@ -332,7 +387,6 @@ fn populate_target(data: &mut Tsdb, target: ColumnTarget, rows: RawRows, interva
                 }
             }
         }
-        _ => panic!("fetch_dispatch must return RawRows matching the ColumnTarget kind"),
     }
 }
 
@@ -372,9 +426,9 @@ fn classify_columns(meta: &ArrowReaderMetadata) -> Result<Vec<ColumnTarget>, Box
         .fields()
         .iter()
         .enumerate()
-        .map(|(col_idx, field)| {
+        .filter_map(|(col_idx, field)| {
             if col_idx == ts_col_idx {
-                return ColumnTarget::Skip;
+                return None;
             }
             let mut field_meta = field.metadata().clone();
             let column_name = field.name().to_string();
@@ -405,31 +459,29 @@ fn classify_columns(meta: &ArrowReaderMetadata) -> Result<Vec<ColumnTarget>, Box
             }
 
             match field.data_type() {
-                DataType::UInt64 => ColumnTarget::Counter {
+                DataType::UInt64 => Some(ColumnTarget::Counter {
                     name,
                     labels,
                     column_name,
-                },
-                DataType::Int64 => ColumnTarget::Gauge {
+                }),
+                DataType::Int64 => Some(ColumnTarget::Gauge {
                     name,
                     labels,
                     column_name,
-                },
+                }),
                 DataType::List(inner) if inner.data_type() == &DataType::UInt64 => {
-                    let (Some(gp), Some(mvp)) = (grouping_power, max_value_power) else {
-                        return ColumnTarget::Skip;
-                    };
+                    let (gp, mvp) = (grouping_power?, max_value_power?);
                     let config = ::histogram::Config::new(gp, mvp).ok();
-                    ColumnTarget::Histogram {
+                    Some(ColumnTarget::Histogram {
                         name,
                         labels,
                         column_name,
                         grouping_power: gp,
                         max_value_power: mvp,
                         config,
-                    }
+                    })
                 }
-                _ => ColumnTarget::Skip,
+                _ => None,
             }
         })
         .collect())
@@ -439,7 +491,7 @@ fn classify_columns(meta: &ArrowReaderMetadata) -> Result<Vec<ColumnTarget>, Box
 /// the priming and the replenish sites in `run_pool_load` use the
 /// exact same closure shape.
 fn spawn_fetch(
-    set: &mut JoinSet<Result<(ColumnTarget, RawRows), FetchError>>,
+    set: &mut JoinSet<Result<FetchResult, FetchError>>,
     target: ColumnTarget,
     pool: Arc<ConnPool>,
     parquet_path: Arc<str>,
@@ -448,9 +500,9 @@ fn spawn_fetch(
     set.spawn_blocking(move || {
         let _keepalive = tempfile_keepalive;
         let mut conn = pool.acquire();
-        let result = fetch_dispatch(&mut conn, &parquet_path, &target);
+        let result = fetch_dispatch(&mut conn, &parquet_path, target);
         pool.release(conn);
-        result.map(|rows| (target, rows))
+        result
     });
 }
 
@@ -564,18 +616,15 @@ impl Tsdb {
         let interval_ns = data.sampling_interval_ms * 1_000_000;
         let pool = Arc::new(ConnPool::new(DEFAULT_POOL_SIZE)?);
 
-        // Drop Skip targets up front; reverse so `pop()` yields the
-        // remaining targets in their original (schema) order. Order
-        // doesn't affect correctness — fetches are independent across
-        // columns and histogram `prev` lives inside one column — but
-        // keeping schema order makes any debug output predictable.
-        let mut targets: Vec<ColumnTarget> = targets
-            .into_iter()
-            .filter(|t| !matches!(t, ColumnTarget::Skip))
-            .collect();
+        // Reverse so `pop()` yields targets in their original (schema)
+        // order. Order doesn't affect correctness — fetches are
+        // independent across columns and histogram `prev` lives inside
+        // one column — but keeping schema order makes any debug output
+        // predictable.
+        let mut targets = targets;
         targets.reverse();
 
-        let mut set: JoinSet<Result<(ColumnTarget, RawRows), FetchError>> = JoinSet::new();
+        let mut set: JoinSet<Result<FetchResult, FetchError>> = JoinSet::new();
 
         // Prime: spawn up to POOL_SIZE tasks immediately.
         for _ in 0..DEFAULT_POOL_SIZE.min(targets.len()) {
@@ -594,8 +643,8 @@ impl Tsdb {
         // completion order, not submission order — fine, populate_target
         // is independent across columns.
         while let Some(join_result) = set.join_next().await {
-            let (target, rows) = join_result??;
-            populate_target(data, target, rows, interval_ns);
+            let result = join_result??;
+            apply_fetch_result(data, result, interval_ns);
 
             if let Some(next) = targets.pop() {
                 spawn_fetch(

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -1,16 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::error::Error;
+use std::io::Write;
 use std::ops::*;
 use std::path::Path;
 
-use arrow::array::{Int64Array, ListArray, UInt64Array};
 use arrow::datatypes::DataType;
 use bytes::Bytes;
+use duckdb::types::Value as DuckValue;
 use histogram::{CumulativeROHistogram, Histogram};
-use parquet::arrow::arrow_reader::{
-    ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
-};
-use parquet::arrow::ProjectionMask;
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use serde::Serialize;
 
 mod collection;
@@ -25,10 +23,9 @@ pub use series::*;
 use series::{delta_to_32_or_empty, empty_delta_32};
 
 /// Per-column dispatch target precomputed from the parquet schema.
-/// Histogram targets carry the rolling `prev` cumulative so per-period
-/// deltas work across batches. `column_name` is the parquet field
-/// name, preserved so callers can map a resolved series back to its
-/// on-disk column without re-parsing the schema.
+/// `column_name` is the parquet field name, preserved so callers can map
+/// a resolved series back to its on-disk column without re-parsing the
+/// schema.
 enum ColumnTarget {
     Skip,
     Counter {
@@ -48,7 +45,6 @@ enum ColumnTarget {
         grouping_power: u8,
         max_value_power: u8,
         config: Option<::histogram::Config>,
-        prev: Option<CumulativeROHistogram>,
     },
 }
 
@@ -100,14 +96,13 @@ impl Tsdb {
     pub fn load_from_bytes(bytes: Bytes) -> Result<Self, Box<dyn Error>> {
         let mut data = Tsdb::default();
 
-        // Parse the footer once and reuse for every per-(row-group, column)
-        // reader below — `try_new` re-parses on every call (multi-second on
-        // wide files).
+        // Parse the footer once for schema/labels inspection. We continue to
+        // read per-column Arrow field metadata via the `parquet` crate because
+        // DuckDB doesn't expose it through SQL; data fetch is delegated to
+        // DuckDB below.
         let arrow_reader_meta = ArrowReaderMetadata::load(&bytes, ArrowReaderOptions::default())?;
         let arrow_schema = arrow_reader_meta.schema().clone();
-        let pq_metadata = arrow_reader_meta.metadata().clone();
-        let parquet_schema = pq_metadata.file_metadata().schema_descr_ptr();
-        let num_row_groups = pq_metadata.num_row_groups();
+        let pq_metadata = arrow_reader_meta.metadata();
 
         let mut metadata = HashMap::new();
         if let Some(kv) = pq_metadata.file_metadata().key_value_metadata() {
@@ -138,7 +133,7 @@ impl Tsdb {
 
         // Precompute targets so the hot loop doesn't re-parse schema
         // metadata per batch.
-        let mut targets: Vec<ColumnTarget> = arrow_schema
+        let targets: Vec<ColumnTarget> = arrow_schema
             .fields()
             .iter()
             .enumerate()
@@ -195,7 +190,6 @@ impl Tsdb {
                             grouping_power: gp,
                             max_value_power: mvp,
                             config,
-                            prev: None,
                         }
                     }
                     _ => ColumnTarget::Skip,
@@ -203,172 +197,167 @@ impl Tsdb {
             })
             .collect();
 
-        // Decode one column at a time within each row group; peak resident
-        // is bounded by one decoded Arrow array.
-        let mut timestamps: Vec<Option<u64>> = Vec::new();
-        for rg_idx in 0..num_row_groups {
-            let ts_reader = ParquetRecordBatchReaderBuilder::new_with_metadata(
-                bytes.clone(),
-                arrow_reader_meta.clone(),
-            )
-            .with_row_groups(vec![rg_idx])
-            .with_projection(ProjectionMask::roots(&parquet_schema, [ts_col_idx]))
-            .build()?;
-            timestamps.clear();
-            for batch in ts_reader.flatten() {
-                let ts_arr = batch
-                    .column(0)
-                    .as_any()
-                    .downcast_ref::<UInt64Array>()
-                    .ok_or("timestamp column is not UInt64")?;
-                timestamps.reserve(ts_arr.len());
-                for v in ts_arr.iter() {
-                    timestamps.push(v.map(|raw| snap_timestamp(raw, interval_ns)));
-                }
-            }
+        // DuckDB needs a filesystem path for `read_parquet`. Materialize the
+        // input bytes to a tempfile so the loader has a single code path for
+        // both `load(path)` (which round-trips through bytes) and direct
+        // `load_from_bytes` callers. The schema work above already happened
+        // on `bytes` directly, so the tempfile is only used for the data
+        // fetch below.
+        let mut tmp = tempfile::NamedTempFile::new()?;
+        tmp.as_file_mut().write_all(&bytes)?;
+        tmp.as_file_mut().sync_all()?;
+        let parquet_path = tmp
+            .path()
+            .to_str()
+            .ok_or("tempfile path is not valid UTF-8")?
+            .to_string();
 
-            for (col_idx, target) in targets.iter_mut().enumerate() {
-                if col_idx == ts_col_idx {
-                    continue;
-                }
-                if matches!(target, ColumnTarget::Skip) {
-                    continue;
-                }
+        let conn = duckdb::Connection::open_in_memory()?;
 
-                let reader = ParquetRecordBatchReaderBuilder::new_with_metadata(
-                    bytes.clone(),
-                    arrow_reader_meta.clone(),
-                )
-                .with_row_groups(vec![rg_idx])
-                .with_projection(ProjectionMask::roots(&parquet_schema, [col_idx]))
-                .build()?;
+        // One SELECT per non-Skip column, returning (timestamp, value) pairs.
+        // Pairing timestamp with the value in the same query removes the
+        // row-index alignment dance the prior `parquet` code carried across
+        // batches. `ORDER BY timestamp` keeps inserts in ascending order so
+        // `Series::insert` stays on its O(1) append fast path (and is
+        // load-bearing for histograms, where deltas are computed against the
+        // immediately preceding snapshot via the stack-local `prev`).
+        for target in targets.iter() {
+            match target {
+                ColumnTarget::Skip => continue,
+                ColumnTarget::Counter {
+                    name,
+                    labels,
+                    column_name,
+                } => {
+                    data.columns
+                        .entry(name.clone())
+                        .or_default()
+                        .insert(labels.clone(), column_name.clone());
+                    let series = data
+                        .counters
+                        .entry(name.clone())
+                        .or_default()
+                        .entry(labels.clone())
+                        .or_default();
 
-                match target {
-                    ColumnTarget::Skip => unreachable!(),
-                    ColumnTarget::Counter {
-                        name,
-                        labels,
-                        column_name,
-                    } => {
-                        data.columns
-                            .entry(name.clone())
-                            .or_default()
-                            .insert(labels.clone(), column_name.clone());
-                        let series = data
-                            .counters
-                            .entry(name.clone())
-                            .or_default()
-                            .entry(labels.clone())
-                            .or_default();
-                        let mut row = 0usize;
-                        for batch in reader.flatten() {
-                            let arr = batch
-                                .column(0)
-                                .as_any()
-                                .downcast_ref::<UInt64Array>()
-                                .expect("counter column is not UInt64");
-                            for v in arr.iter() {
-                                if let (Some(v), Some(Some(ts))) = (v, timestamps.get(row)) {
-                                    series.insert(*ts, v);
-                                }
-                                row += 1;
-                            }
-                        }
+                    let sql = format!(
+                        r#"SELECT timestamp, "{col}" FROM read_parquet(?)
+                           WHERE timestamp IS NOT NULL AND "{col}" IS NOT NULL
+                           ORDER BY timestamp"#,
+                        col = column_name.replace('"', "\"\"")
+                    );
+                    let mut stmt = conn.prepare(&sql)?;
+                    let rows = stmt.query_map([&parquet_path], |row| {
+                        Ok((row.get::<_, u64>(0)?, row.get::<_, u64>(1)?))
+                    })?;
+                    for r in rows {
+                        let (ts_raw, v) = r?;
+                        series.insert(snap_timestamp(ts_raw, interval_ns), v);
                     }
-                    ColumnTarget::Gauge {
-                        name,
-                        labels,
-                        column_name,
-                    } => {
-                        data.columns
-                            .entry(name.clone())
-                            .or_default()
-                            .insert(labels.clone(), column_name.clone());
-                        let series = data
-                            .gauges
-                            .entry(name.clone())
-                            .or_default()
-                            .entry(labels.clone())
-                            .or_default();
-                        let mut row = 0usize;
-                        for batch in reader.flatten() {
-                            let arr = batch
-                                .column(0)
-                                .as_any()
-                                .downcast_ref::<Int64Array>()
-                                .expect("gauge column is not Int64");
-                            for v in arr.iter() {
-                                if let (Some(v), Some(Some(ts))) = (v, timestamps.get(row)) {
-                                    series.insert(*ts, v);
-                                }
-                                row += 1;
-                            }
-                        }
+                }
+                ColumnTarget::Gauge {
+                    name,
+                    labels,
+                    column_name,
+                } => {
+                    data.columns
+                        .entry(name.clone())
+                        .or_default()
+                        .insert(labels.clone(), column_name.clone());
+                    let series = data
+                        .gauges
+                        .entry(name.clone())
+                        .or_default()
+                        .entry(labels.clone())
+                        .or_default();
+
+                    let sql = format!(
+                        r#"SELECT timestamp, "{col}" FROM read_parquet(?)
+                           WHERE timestamp IS NOT NULL AND "{col}" IS NOT NULL
+                           ORDER BY timestamp"#,
+                        col = column_name.replace('"', "\"\"")
+                    );
+                    let mut stmt = conn.prepare(&sql)?;
+                    let rows = stmt.query_map([&parquet_path], |row| {
+                        Ok((row.get::<_, u64>(0)?, row.get::<_, i64>(1)?))
+                    })?;
+                    for r in rows {
+                        let (ts_raw, v) = r?;
+                        series.insert(snap_timestamp(ts_raw, interval_ns), v);
                     }
-                    ColumnTarget::Histogram {
-                        ref name,
-                        ref labels,
-                        ref column_name,
-                        grouping_power,
-                        max_value_power,
-                        ref config,
-                        ref mut prev,
-                    } => {
-                        let gp = *grouping_power;
-                        let mvp = *max_value_power;
-                        let cfg = *config;
-                        data.columns
-                            .entry(name.clone())
-                            .or_default()
-                            .insert(labels.clone(), column_name.clone());
-                        let series = data
-                            .histograms
-                            .entry(name.clone())
-                            .or_default()
-                            .entry(labels.clone())
-                            .or_default();
+                }
+                ColumnTarget::Histogram {
+                    name,
+                    labels,
+                    column_name,
+                    grouping_power,
+                    max_value_power,
+                    config,
+                } => {
+                    let gp = *grouping_power;
+                    let mvp = *max_value_power;
+                    let cfg = *config;
+                    data.columns
+                        .entry(name.clone())
+                        .or_default()
+                        .insert(labels.clone(), column_name.clone());
+                    let series = data
+                        .histograms
+                        .entry(name.clone())
+                        .or_default()
+                        .entry(labels.clone())
+                        .or_default();
 
-                        let mut row = 0usize;
-                        for batch in reader.flatten() {
-                            let list = batch
-                                .column(0)
-                                .as_any()
-                                .downcast_ref::<ListArray>()
-                                .expect("histogram column is not List");
-                            for value in list.iter() {
-                                let Some(Some(ts)) = timestamps.get(row).copied() else {
-                                    row += 1;
-                                    continue;
-                                };
+                    // Null bucket lists are kept (not WHERE-filtered) so a
+                    // missing snapshot still produces an explicit empty
+                    // delta against `prev` — matches the prior loader and
+                    // keeps offset-based timestamp axes aligned.
+                    let sql = format!(
+                        r#"SELECT timestamp, "{col}" FROM read_parquet(?)
+                           WHERE timestamp IS NOT NULL
+                           ORDER BY timestamp"#,
+                        col = column_name.replace('"', "\"\"")
+                    );
+                    let mut stmt = conn.prepare(&sql)?;
+                    let rows = stmt.query_map([&parquet_path], |row| {
+                        Ok((row.get::<_, u64>(0)?, row.get::<_, DuckValue>(1)?))
+                    })?;
 
-                                let curr = value.and_then(|list_value| {
-                                    let arr = list_value
-                                        .as_any()
-                                        .downcast_ref::<UInt64Array>()
-                                        .expect("histogram inner is not UInt64");
-                                    let buckets: Vec<u64> = arr.iter().flatten().collect();
-                                    Histogram::from_buckets(gp, mvp, buckets)
-                                        .ok()
-                                        .map(|h| CumulativeROHistogram::from(&h))
-                                });
+                    let mut prev: Option<CumulativeROHistogram> = None;
+                    for r in rows {
+                        let (ts_raw, val) = r?;
+                        let ts = snap_timestamp(ts_raw, interval_ns);
 
-                                match (prev.as_ref(), curr.as_ref()) {
-                                    (Some(prev_cumu), Some(curr_cumu)) => {
-                                        series
-                                            .insert(ts, delta_to_32_or_empty(prev_cumu, curr_cumu));
-                                    }
-                                    (Some(_), None) => {
-                                        if let Some(cfg) = cfg {
-                                            series.insert(ts, empty_delta_32(cfg));
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                                if curr.is_some() {
-                                    *prev = curr;
-                                }
-                                row += 1;
+                        let curr = match val {
+                            DuckValue::List(elems) => {
+                                let buckets: Vec<u64> = elems
+                                    .iter()
+                                    .map(|v| match v {
+                                        DuckValue::UBigInt(x) => *x,
+                                        DuckValue::Null => 0,
+                                        _ => panic!("histogram inner is not UBIGINT"),
+                                    })
+                                    .collect();
+                                Histogram::from_buckets(gp, mvp, buckets)
+                                    .ok()
+                                    .map(|h| CumulativeROHistogram::from(&h))
                             }
+                            _ => None,
+                        };
+
+                        match (prev.as_ref(), curr.as_ref()) {
+                            (Some(prev_cumu), Some(curr_cumu)) => {
+                                series.insert(ts, delta_to_32_or_empty(prev_cumu, curr_cumu));
+                            }
+                            (Some(_), None) => {
+                                if let Some(cfg) = cfg {
+                                    series.insert(ts, empty_delta_32(cfg));
+                                }
+                            }
+                            _ => {}
+                        }
+                        if curr.is_some() {
+                            prev = curr;
                         }
                     }
                 }

--- a/metriken-query/src/tsdb/mod.rs
+++ b/metriken-query/src/tsdb/mod.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::io::Write;
 use std::ops::*;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use arrow::datatypes::DataType;
 use bytes::Bytes;
@@ -10,6 +11,14 @@ use duckdb::types::Value as DuckValue;
 use histogram::{CumulativeROHistogram, Histogram};
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use serde::Serialize;
+use tokio::task::JoinSet;
+
+/// How many DuckDB connections (and therefore concurrent column fetches) the
+/// load path runs in parallel. DuckDB connections are single-threaded, so this
+/// caps how many SELECTs can be in flight at once. 4 is a balance between
+/// parallelism and not over-subscribing DuckDB's internal parquet-reader
+/// threads.
+const DEFAULT_POOL_SIZE: usize = 4;
 
 mod collection;
 mod heatmap;
@@ -65,11 +74,384 @@ fn snap_timestamp(ts: u64, interval_ns: u64) -> u64 {
 /// because some SQL parsers treat them as string terminators; every
 /// other character is permitted inside ANSI/DuckDB quoted identifiers as
 /// long as embedded double quotes are doubled.
-fn quote_ident(name: &str) -> Result<String, Box<dyn Error>> {
+fn quote_ident(name: &str) -> Result<String, FetchError> {
     if name.as_bytes().contains(&0) {
-        return Err(format!("column name contains NUL byte: {name:?}").into());
+        return Err(FetchError::BadIdentifier(format!(
+            "column name contains NUL byte: {name:?}"
+        )));
     }
     Ok(format!("\"{}\"", name.replace('"', "\"\"")))
+}
+
+/// Error type for the per-column fetch path. Concrete (rather than
+/// `Box<dyn Error>`) so it satisfies `Send + Sync + 'static` for
+/// `JoinSet::spawn_blocking`.
+#[derive(Debug, thiserror::Error)]
+enum FetchError {
+    #[error("duckdb error: {0}")]
+    Duckdb(#[from] duckdb::Error),
+    #[error("bad column identifier: {0}")]
+    BadIdentifier(String),
+    #[error("histogram bucket element was not UBIGINT")]
+    BadHistogramBucket,
+}
+
+/// Small fixed-size pool of in-memory DuckDB connections. Connections are
+/// stateless wrt parquet (every query is `read_parquet(?)`), so any
+/// available connection can serve any column fetch. Acquire/release runs
+/// inside `spawn_blocking`, so a `std::sync::Mutex` is correct — no async
+/// awaiting while the mutex is held.
+struct ConnPool {
+    inner: Mutex<Vec<duckdb::Connection>>,
+}
+
+impl ConnPool {
+    fn new(size: usize) -> Result<Self, duckdb::Error> {
+        let conns: Result<Vec<_>, _> = (0..size)
+            .map(|_| duckdb::Connection::open_in_memory())
+            .collect();
+        Ok(Self {
+            inner: Mutex::new(conns?),
+        })
+    }
+
+    /// Pop a connection from the pool. Callers must `release` it back
+    /// when done. Pool exhaustion is impossible by construction —
+    /// `run_pool_load` caps in-flight tasks at the pool size.
+    fn acquire(&self) -> duckdb::Connection {
+        self.inner
+            .lock()
+            .expect("conn pool mutex poisoned")
+            .pop()
+            .expect("conn pool exhausted — should be bounded by JoinSet size")
+    }
+
+    fn release(&self, conn: duckdb::Connection) {
+        self.inner
+            .lock()
+            .expect("conn pool mutex poisoned")
+            .push(conn);
+    }
+}
+
+/// Untyped per-column rows returned from a worker task. Pairs with the
+/// matching `ColumnTarget` so the post-fetch sync pass knows how to
+/// fold each batch into the in-memory series.
+enum RawRows {
+    Counter(Vec<(u64, u64)>),
+    Gauge(Vec<(u64, i64)>),
+    Histogram(Vec<(u64, Option<Vec<u64>>)>),
+}
+
+fn fetch_counter_column(
+    conn: &mut duckdb::Connection,
+    parquet_path: &str,
+    column_name: &str,
+) -> Result<Vec<(u64, u64)>, FetchError> {
+    let col = quote_ident(column_name)?;
+    let sql = format!(
+        "SELECT timestamp, {col} FROM read_parquet(?) \
+         WHERE timestamp IS NOT NULL AND {col} IS NOT NULL \
+         ORDER BY timestamp"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([parquet_path], |row| {
+        Ok((row.get::<_, u64>(0)?, row.get::<_, u64>(1)?))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn fetch_gauge_column(
+    conn: &mut duckdb::Connection,
+    parquet_path: &str,
+    column_name: &str,
+) -> Result<Vec<(u64, i64)>, FetchError> {
+    let col = quote_ident(column_name)?;
+    let sql = format!(
+        "SELECT timestamp, {col} FROM read_parquet(?) \
+         WHERE timestamp IS NOT NULL AND {col} IS NOT NULL \
+         ORDER BY timestamp"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([parquet_path], |row| {
+        Ok((row.get::<_, u64>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn fetch_histogram_column(
+    conn: &mut duckdb::Connection,
+    parquet_path: &str,
+    column_name: &str,
+) -> Result<Vec<(u64, Option<Vec<u64>>)>, FetchError> {
+    let col = quote_ident(column_name)?;
+    // Null bucket lists are kept (not WHERE-filtered) so the post-fetch
+    // pass still emits an explicit empty delta against `prev` at those
+    // timestamps — matches the prior loader and keeps offset-based
+    // timestamp axes aligned.
+    let sql = format!(
+        "SELECT timestamp, {col} FROM read_parquet(?) \
+         WHERE timestamp IS NOT NULL \
+         ORDER BY timestamp"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([parquet_path], |row| {
+        Ok((row.get::<_, u64>(0)?, row.get::<_, DuckValue>(1)?))
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        let (ts, val) = r?;
+        let buckets = match val {
+            DuckValue::List(elems) => {
+                let mut buckets = Vec::with_capacity(elems.len());
+                for v in elems {
+                    match v {
+                        DuckValue::UBigInt(x) => buckets.push(x),
+                        DuckValue::Null => buckets.push(0),
+                        _ => return Err(FetchError::BadHistogramBucket),
+                    }
+                }
+                Some(buckets)
+            }
+            _ => None,
+        };
+        out.push((ts, buckets));
+    }
+    Ok(out)
+}
+
+fn fetch_dispatch(
+    conn: &mut duckdb::Connection,
+    parquet_path: &str,
+    target: &ColumnTarget,
+) -> Result<RawRows, FetchError> {
+    match target {
+        ColumnTarget::Counter { column_name, .. } => {
+            fetch_counter_column(conn, parquet_path, column_name).map(RawRows::Counter)
+        }
+        ColumnTarget::Gauge { column_name, .. } => {
+            fetch_gauge_column(conn, parquet_path, column_name).map(RawRows::Gauge)
+        }
+        ColumnTarget::Histogram { column_name, .. } => {
+            fetch_histogram_column(conn, parquet_path, column_name).map(RawRows::Histogram)
+        }
+        ColumnTarget::Skip => panic!("Skip targets must be filtered out before dispatch"),
+    }
+}
+
+/// Fold one fetched column's raw rows into the in-memory `Tsdb`.
+/// Mirrors the per-arm logic of the old synchronous loader exactly —
+/// only the data source is different.
+fn populate_target(data: &mut Tsdb, target: ColumnTarget, rows: RawRows, interval_ns: u64) {
+    match (target, rows) {
+        (
+            ColumnTarget::Counter {
+                name,
+                labels,
+                column_name,
+            },
+            RawRows::Counter(rows),
+        ) => {
+            data.columns
+                .entry(name.clone())
+                .or_default()
+                .insert(labels.clone(), column_name);
+            let series = data
+                .counters
+                .entry(name)
+                .or_default()
+                .entry(labels)
+                .or_default();
+            for (ts_raw, v) in rows {
+                series.insert(snap_timestamp(ts_raw, interval_ns), v);
+            }
+        }
+        (
+            ColumnTarget::Gauge {
+                name,
+                labels,
+                column_name,
+            },
+            RawRows::Gauge(rows),
+        ) => {
+            data.columns
+                .entry(name.clone())
+                .or_default()
+                .insert(labels.clone(), column_name);
+            let series = data
+                .gauges
+                .entry(name)
+                .or_default()
+                .entry(labels)
+                .or_default();
+            for (ts_raw, v) in rows {
+                series.insert(snap_timestamp(ts_raw, interval_ns), v);
+            }
+        }
+        (
+            ColumnTarget::Histogram {
+                name,
+                labels,
+                column_name,
+                grouping_power,
+                max_value_power,
+                config,
+            },
+            RawRows::Histogram(rows),
+        ) => {
+            data.columns
+                .entry(name.clone())
+                .or_default()
+                .insert(labels.clone(), column_name);
+            let series = data
+                .histograms
+                .entry(name)
+                .or_default()
+                .entry(labels)
+                .or_default();
+
+            let mut prev: Option<CumulativeROHistogram> = None;
+            for (ts_raw, buckets) in rows {
+                let ts = snap_timestamp(ts_raw, interval_ns);
+                let curr = buckets.and_then(|b| {
+                    Histogram::from_buckets(grouping_power, max_value_power, b)
+                        .ok()
+                        .map(|h| CumulativeROHistogram::from(&h))
+                });
+                match (prev.as_ref(), curr.as_ref()) {
+                    (Some(p), Some(c)) => series.insert(ts, delta_to_32_or_empty(p, c)),
+                    (Some(_), None) => {
+                        if let Some(cfg) = config {
+                            series.insert(ts, empty_delta_32(cfg));
+                        }
+                    }
+                    _ => {}
+                }
+                if curr.is_some() {
+                    prev = curr;
+                }
+            }
+        }
+        _ => panic!("fetch_dispatch must return RawRows matching the ColumnTarget kind"),
+    }
+}
+
+/// Extract file-level kv metadata and populate `data`'s metadata fields.
+fn populate_metadata(data: &mut Tsdb, meta: &ArrowReaderMetadata) {
+    let mut kv = HashMap::new();
+    if let Some(entries) = meta.metadata().file_metadata().key_value_metadata() {
+        for entry in entries {
+            kv.insert(entry.key.clone(), entry.value.clone().unwrap_or_default());
+        }
+    }
+    data.sampling_interval_ms = kv
+        .get("sampling_interval_ms")
+        .map(|v| v.parse::<u64>().expect("bad interval"))
+        .unwrap_or(1000);
+    data.source = kv
+        .get("source")
+        .cloned()
+        .unwrap_or_else(|| "unknown".to_string());
+    data.version = kv
+        .get("version")
+        .cloned()
+        .unwrap_or_else(|| "unknown".to_string());
+    data.file_metadata = kv;
+}
+
+/// Classify each parquet column into a `ColumnTarget` based on its
+/// Arrow field metadata. DuckDB doesn't surface per-field metadata
+/// through SQL, so this stays on the `parquet` crate path.
+fn classify_columns(meta: &ArrowReaderMetadata) -> Result<Vec<ColumnTarget>, Box<dyn Error>> {
+    let schema = meta.schema();
+    let ts_col_idx = schema
+        .index_of("timestamp")
+        .map_err(|_| "missing 'timestamp' column")?;
+
+    Ok(schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(col_idx, field)| {
+            if col_idx == ts_col_idx {
+                return ColumnTarget::Skip;
+            }
+            let mut field_meta = field.metadata().clone();
+            let column_name = field.name().to_string();
+            let name = if let Some(n) = field_meta.get("metric").cloned() {
+                n
+            } else {
+                column_name
+                    .strip_suffix(":buckets")
+                    .unwrap_or(&column_name)
+                    .to_string()
+            };
+            let grouping_power: Option<u8> = field_meta
+                .remove("grouping_power")
+                .and_then(|v| v.parse().ok());
+            let max_value_power: Option<u8> = field_meta
+                .remove("max_value_power")
+                .and_then(|v| v.parse().ok());
+
+            let mut labels = Labels::default();
+            for (k, v) in field_meta.iter() {
+                match k.as_str() {
+                    // Internal metadata — not user-facing labels
+                    "metric" | "metric_type" | "unit" => continue,
+                    _ => {
+                        labels.inner.insert(k.to_string(), v.to_string());
+                    }
+                }
+            }
+
+            match field.data_type() {
+                DataType::UInt64 => ColumnTarget::Counter {
+                    name,
+                    labels,
+                    column_name,
+                },
+                DataType::Int64 => ColumnTarget::Gauge {
+                    name,
+                    labels,
+                    column_name,
+                },
+                DataType::List(inner) if inner.data_type() == &DataType::UInt64 => {
+                    let (Some(gp), Some(mvp)) = (grouping_power, max_value_power) else {
+                        return ColumnTarget::Skip;
+                    };
+                    let config = ::histogram::Config::new(gp, mvp).ok();
+                    ColumnTarget::Histogram {
+                        name,
+                        labels,
+                        column_name,
+                        grouping_power: gp,
+                        max_value_power: mvp,
+                        config,
+                    }
+                }
+                _ => ColumnTarget::Skip,
+            }
+        })
+        .collect())
+}
+
+/// Spawn one column-fetch task onto the JoinSet. Factored out so both
+/// the priming and the replenish sites in `run_pool_load` use the
+/// exact same closure shape.
+fn spawn_fetch(
+    set: &mut JoinSet<Result<(ColumnTarget, RawRows), FetchError>>,
+    target: ColumnTarget,
+    pool: Arc<ConnPool>,
+    parquet_path: Arc<str>,
+    tempfile_keepalive: Option<Arc<tempfile::NamedTempFile>>,
+) {
+    set.spawn_blocking(move || {
+        let _keepalive = tempfile_keepalive;
+        let mut conn = pool.acquire();
+        let result = fetch_dispatch(&mut conn, &parquet_path, &target);
+        pool.release(conn);
+        result.map(|rows| (target, rows))
+    });
 }
 
 #[derive(Default, Clone)]
@@ -95,290 +477,138 @@ pub struct Tsdb {
 }
 
 impl Tsdb {
-    pub fn load(path: &Path) -> Result<Self, Box<dyn Error>> {
-        let raw = std::fs::read(path)?;
+    /// Load a parquet file into an in-memory TSDB. DuckDB reads the file
+    /// directly from `path` (no extra in-memory copy) and per-column
+    /// SELECTs run on a small connection pool concurrently. Requires a
+    /// tokio runtime to await.
+    pub async fn load(path: &Path) -> Result<Self, Box<dyn Error>> {
         let filename = path
             .file_name()
-            .map(|v| v.to_str().unwrap_or("unknown"))
+            .and_then(|v| v.to_str())
             .unwrap_or("unknown")
             .to_string();
-        let mut data = Self::load_from_bytes(Bytes::from(raw))?;
+        let path_str: Arc<str> =
+            Arc::from(path.to_str().ok_or("path is not valid UTF-8")?);
+
+        // Footer read is small (KB) but still blocking I/O; off the
+        // async runtime. `parquet::errors::ParquetError` has a From
+        // impl for io::Error, so both possible failure modes
+        // collapse into one concrete error type that `?` can box.
+        let path_owned = path.to_owned();
+        let meta = tokio::task::spawn_blocking(
+            move || -> Result<_, parquet::errors::ParquetError> {
+                let file = std::fs::File::open(&path_owned)?;
+                let m = ArrowReaderMetadata::load(&file, ArrowReaderOptions::default())?;
+                Ok(m)
+            },
+        )
+        .await??;
+
+        let mut data = Tsdb::default();
+        populate_metadata(&mut data, &meta);
+        let targets = classify_columns(&meta)?;
+
+        Self::run_pool_load(&mut data, path_str, targets, None).await?;
         data.filename = filename;
         Ok(data)
     }
 
-    pub fn load_from_bytes(bytes: Bytes) -> Result<Self, Box<dyn Error>> {
+    /// Load from an in-memory parquet buffer. DuckDB requires a
+    /// filesystem path, so the bytes are materialized to a tempfile
+    /// that's held alive until every column fetch finishes. Requires a
+    /// tokio runtime to await.
+    pub async fn load_from_bytes(bytes: Bytes) -> Result<Self, Box<dyn Error>> {
+        // Schema discovery is cheap and can happen on `bytes` directly
+        // before we move them into the tempfile-writing task.
+        let meta = ArrowReaderMetadata::load(&bytes, ArrowReaderOptions::default())?;
         let mut data = Tsdb::default();
+        populate_metadata(&mut data, &meta);
+        let targets = classify_columns(&meta)?;
 
-        // Parse the footer once for schema/labels inspection. We continue to
-        // read per-column Arrow field metadata via the `parquet` crate because
-        // DuckDB doesn't expose it through SQL; data fetch is delegated to
-        // DuckDB below.
-        let arrow_reader_meta = ArrowReaderMetadata::load(&bytes, ArrowReaderOptions::default())?;
-        let arrow_schema = arrow_reader_meta.schema().clone();
-        let pq_metadata = arrow_reader_meta.metadata();
+        // Tempfile creation involves blocking syscalls; do them on the
+        // blocking pool.
+        let tempfile = tokio::task::spawn_blocking(move || -> Result<_, std::io::Error> {
+            let mut tmp = tempfile::NamedTempFile::new()?;
+            tmp.as_file_mut().write_all(&bytes)?;
+            tmp.as_file_mut().sync_all()?;
+            Ok(tmp)
+        })
+        .await??;
 
-        let mut metadata = HashMap::new();
-        if let Some(kv) = pq_metadata.file_metadata().key_value_metadata() {
-            for entry in kv {
-                metadata.insert(entry.key.clone(), entry.value.clone().unwrap_or_default());
-            }
-        }
+        let parquet_path: Arc<str> = Arc::from(
+            tempfile
+                .path()
+                .to_str()
+                .ok_or("tempfile path is not valid UTF-8")?
+                .to_string()
+                .as_str(),
+        );
+        let tempfile = Arc::new(tempfile);
 
-        data.sampling_interval_ms = metadata
-            .get("sampling_interval_ms")
-            .map(|v| v.parse::<u64>().expect("bad interval"))
-            .unwrap_or(1000);
-        data.source = metadata
-            .get("source")
-            .cloned()
-            .unwrap_or_else(|| "unknown".to_string());
-        data.version = metadata
-            .get("version")
-            .cloned()
-            .unwrap_or_else(|| "unknown".to_string());
-        data.file_metadata = metadata;
-
-        let interval_ns = data.sampling_interval_ms * 1_000_000;
-
-        let ts_col_idx = arrow_schema
-            .index_of("timestamp")
-            .map_err(|_| "missing 'timestamp' column")?;
-
-        // Precompute targets so the hot loop doesn't re-parse schema
-        // metadata per batch.
-        let targets: Vec<ColumnTarget> = arrow_schema
-            .fields()
-            .iter()
-            .enumerate()
-            .map(|(col_idx, field)| {
-                if col_idx == ts_col_idx {
-                    return ColumnTarget::Skip;
-                }
-                let mut meta = field.metadata().clone();
-                let column_name = field.name().to_string();
-                let name = if let Some(n) = meta.get("metric").cloned() {
-                    n
-                } else {
-                    column_name
-                        .strip_suffix(":buckets")
-                        .unwrap_or(&column_name)
-                        .to_string()
-                };
-                let grouping_power: Option<u8> =
-                    meta.remove("grouping_power").and_then(|v| v.parse().ok());
-                let max_value_power: Option<u8> =
-                    meta.remove("max_value_power").and_then(|v| v.parse().ok());
-
-                let mut labels = Labels::default();
-                for (k, v) in meta.iter() {
-                    match k.as_str() {
-                        // Internal metadata — not user-facing labels
-                        "metric" | "metric_type" | "unit" => continue,
-                        _ => {
-                            labels.inner.insert(k.to_string(), v.to_string());
-                        }
-                    }
-                }
-
-                match field.data_type() {
-                    DataType::UInt64 => ColumnTarget::Counter {
-                        name,
-                        labels,
-                        column_name,
-                    },
-                    DataType::Int64 => ColumnTarget::Gauge {
-                        name,
-                        labels,
-                        column_name,
-                    },
-                    DataType::List(inner) if inner.data_type() == &DataType::UInt64 => {
-                        let (Some(gp), Some(mvp)) = (grouping_power, max_value_power) else {
-                            return ColumnTarget::Skip;
-                        };
-                        let config = ::histogram::Config::new(gp, mvp).ok();
-                        ColumnTarget::Histogram {
-                            name,
-                            labels,
-                            column_name,
-                            grouping_power: gp,
-                            max_value_power: mvp,
-                            config,
-                        }
-                    }
-                    _ => ColumnTarget::Skip,
-                }
-            })
-            .collect();
-
-        // DuckDB needs a filesystem path for `read_parquet`. Materialize the
-        // input bytes to a tempfile so the loader has a single code path for
-        // both `load(path)` (which round-trips through bytes) and direct
-        // `load_from_bytes` callers. The schema work above already happened
-        // on `bytes` directly, so the tempfile is only used for the data
-        // fetch below.
-        let mut tmp = tempfile::NamedTempFile::new()?;
-        tmp.as_file_mut().write_all(&bytes)?;
-        tmp.as_file_mut().sync_all()?;
-        let parquet_path = tmp
-            .path()
-            .to_str()
-            .ok_or("tempfile path is not valid UTF-8")?
-            .to_string();
-
-        let conn = duckdb::Connection::open_in_memory()?;
-
-        // One SELECT per non-Skip column, returning (timestamp, value) pairs.
-        // Pairing timestamp with the value in the same query removes the
-        // row-index alignment dance the prior `parquet` code carried across
-        // batches. `ORDER BY timestamp` keeps inserts in ascending order so
-        // `Series::insert` stays on its O(1) append fast path (and is
-        // load-bearing for histograms, where deltas are computed against the
-        // immediately preceding snapshot via the stack-local `prev`).
-        for target in targets.iter() {
-            match target {
-                ColumnTarget::Skip => continue,
-                ColumnTarget::Counter {
-                    name,
-                    labels,
-                    column_name,
-                } => {
-                    data.columns
-                        .entry(name.clone())
-                        .or_default()
-                        .insert(labels.clone(), column_name.clone());
-                    let series = data
-                        .counters
-                        .entry(name.clone())
-                        .or_default()
-                        .entry(labels.clone())
-                        .or_default();
-
-                    let col = quote_ident(column_name)?;
-                    let sql = format!(
-                        "SELECT timestamp, {col} FROM read_parquet(?) \
-                         WHERE timestamp IS NOT NULL AND {col} IS NOT NULL \
-                         ORDER BY timestamp"
-                    );
-                    let mut stmt = conn.prepare(&sql)?;
-                    let rows = stmt.query_map([&parquet_path], |row| {
-                        Ok((row.get::<_, u64>(0)?, row.get::<_, u64>(1)?))
-                    })?;
-                    for r in rows {
-                        let (ts_raw, v) = r?;
-                        series.insert(snap_timestamp(ts_raw, interval_ns), v);
-                    }
-                }
-                ColumnTarget::Gauge {
-                    name,
-                    labels,
-                    column_name,
-                } => {
-                    data.columns
-                        .entry(name.clone())
-                        .or_default()
-                        .insert(labels.clone(), column_name.clone());
-                    let series = data
-                        .gauges
-                        .entry(name.clone())
-                        .or_default()
-                        .entry(labels.clone())
-                        .or_default();
-
-                    let col = quote_ident(column_name)?;
-                    let sql = format!(
-                        "SELECT timestamp, {col} FROM read_parquet(?) \
-                         WHERE timestamp IS NOT NULL AND {col} IS NOT NULL \
-                         ORDER BY timestamp"
-                    );
-                    let mut stmt = conn.prepare(&sql)?;
-                    let rows = stmt.query_map([&parquet_path], |row| {
-                        Ok((row.get::<_, u64>(0)?, row.get::<_, i64>(1)?))
-                    })?;
-                    for r in rows {
-                        let (ts_raw, v) = r?;
-                        series.insert(snap_timestamp(ts_raw, interval_ns), v);
-                    }
-                }
-                ColumnTarget::Histogram {
-                    name,
-                    labels,
-                    column_name,
-                    grouping_power,
-                    max_value_power,
-                    config,
-                } => {
-                    let gp = *grouping_power;
-                    let mvp = *max_value_power;
-                    let cfg = *config;
-                    data.columns
-                        .entry(name.clone())
-                        .or_default()
-                        .insert(labels.clone(), column_name.clone());
-                    let series = data
-                        .histograms
-                        .entry(name.clone())
-                        .or_default()
-                        .entry(labels.clone())
-                        .or_default();
-
-                    // Null bucket lists are kept (not WHERE-filtered) so a
-                    // missing snapshot still produces an explicit empty
-                    // delta against `prev` — matches the prior loader and
-                    // keeps offset-based timestamp axes aligned.
-                    let col = quote_ident(column_name)?;
-                    let sql = format!(
-                        "SELECT timestamp, {col} FROM read_parquet(?) \
-                         WHERE timestamp IS NOT NULL \
-                         ORDER BY timestamp"
-                    );
-                    let mut stmt = conn.prepare(&sql)?;
-                    let rows = stmt.query_map([&parquet_path], |row| {
-                        Ok((row.get::<_, u64>(0)?, row.get::<_, DuckValue>(1)?))
-                    })?;
-
-                    let mut prev: Option<CumulativeROHistogram> = None;
-                    for r in rows {
-                        let (ts_raw, val) = r?;
-                        let ts = snap_timestamp(ts_raw, interval_ns);
-
-                        let curr = match val {
-                            DuckValue::List(elems) => {
-                                let buckets: Vec<u64> = elems
-                                    .iter()
-                                    .map(|v| match v {
-                                        DuckValue::UBigInt(x) => *x,
-                                        DuckValue::Null => 0,
-                                        _ => panic!("histogram inner is not UBIGINT"),
-                                    })
-                                    .collect();
-                                Histogram::from_buckets(gp, mvp, buckets)
-                                    .ok()
-                                    .map(|h| CumulativeROHistogram::from(&h))
-                            }
-                            _ => None,
-                        };
-
-                        match (prev.as_ref(), curr.as_ref()) {
-                            (Some(prev_cumu), Some(curr_cumu)) => {
-                                series.insert(ts, delta_to_32_or_empty(prev_cumu, curr_cumu));
-                            }
-                            (Some(_), None) => {
-                                if let Some(cfg) = cfg {
-                                    series.insert(ts, empty_delta_32(cfg));
-                                }
-                            }
-                            _ => {}
-                        }
-                        if curr.is_some() {
-                            prev = curr;
-                        }
-                    }
-                }
-            }
-        }
-
+        Self::run_pool_load(&mut data, parquet_path, targets, Some(tempfile)).await?;
         Ok(data)
+    }
+
+    /// Drive the per-column fetch loop. A small pool of DuckDB
+    /// connections is created and reused across columns; a JoinSet
+    /// keeps at most `DEFAULT_POOL_SIZE` tasks in flight at any time so
+    /// the pool can never be exhausted. Each completed task's rows are
+    /// folded into `data` synchronously before the next task is
+    /// scheduled.
+    async fn run_pool_load(
+        data: &mut Tsdb,
+        parquet_path: Arc<str>,
+        targets: Vec<ColumnTarget>,
+        tempfile_keepalive: Option<Arc<tempfile::NamedTempFile>>,
+    ) -> Result<(), Box<dyn Error>> {
+        let interval_ns = data.sampling_interval_ms * 1_000_000;
+        let pool = Arc::new(ConnPool::new(DEFAULT_POOL_SIZE)?);
+
+        // Drop Skip targets up front; reverse so `pop()` yields the
+        // remaining targets in their original (schema) order. Order
+        // doesn't affect correctness — fetches are independent across
+        // columns and histogram `prev` lives inside one column — but
+        // keeping schema order makes any debug output predictable.
+        let mut targets: Vec<ColumnTarget> = targets
+            .into_iter()
+            .filter(|t| !matches!(t, ColumnTarget::Skip))
+            .collect();
+        targets.reverse();
+
+        let mut set: JoinSet<Result<(ColumnTarget, RawRows), FetchError>> = JoinSet::new();
+
+        // Prime: spawn up to POOL_SIZE tasks immediately.
+        for _ in 0..DEFAULT_POOL_SIZE.min(targets.len()) {
+            let target = targets.pop().expect("min ensures non-empty");
+            spawn_fetch(
+                &mut set,
+                target,
+                pool.clone(),
+                parquet_path.clone(),
+                tempfile_keepalive.clone(),
+            );
+        }
+
+        // Drain: as each task finishes, fold its rows in and replenish
+        // from the remaining targets. JoinSet hands back results in
+        // completion order, not submission order — fine, populate_target
+        // is independent across columns.
+        while let Some(join_result) = set.join_next().await {
+            let (target, rows) = join_result??;
+            populate_target(data, target, rows, interval_ns);
+
+            if let Some(next) = targets.pop() {
+                spawn_fetch(
+                    &mut set,
+                    next,
+                    pool.clone(),
+                    parquet_path.clone(),
+                    tempfile_keepalive.clone(),
+                );
+            }
+        }
+
+        Ok(())
     }
 
     pub fn set_sampling_interval_ms(&mut self, ms: u64) {


### PR DESCRIPTION
## What this does

Routes `metriken-query`'s parquet load path through DuckDB and makes the loader `async`, so per-column reads run concurrently on a small connection pool. The external API of the `tsdb` module is unchanged for consumers — `counters_ref`, `gauges_ref`, `histograms_ref`, and every getter stay sync and return borrows into the same in-memory `CounterCollection` / `GaugeCollection` / `HistogramCollection` layout. Only the two `load` entry points change shape (they become `async fn`). All 79 existing tests pass, including `cachecannon_smoke_test`, which loads `cachecannon.parquet` and runs every cachecannon dashboard query against the result.

## How

- **DuckDB is the data path.** Each fetchable parquet column is loaded with a per-column `SELECT timestamp, "col" FROM read_parquet(?)`. Schema and label discovery still go through the `parquet` crate's `ArrowReaderMetadata` because DuckDB doesn't expose per-Arrow-field metadata through SQL, and that's where this codebase's labels live.

- **Async loader, bounded connection pool.** A `JoinSet` keeps at most `POOL_SIZE` (default 4) per-column fetch tasks in flight; each task runs sync DuckDB code via `spawn_blocking`. `load(path)` reads only the parquet footer for schema and hands the path directly to DuckDB. `load_from_bytes` materializes a tempfile held alive via `Arc<NamedTempFile>` cloned into every spawned task.

- **SQL identifiers go through a central `quote_ident` helper** that double-quotes the column name, doubles embedded `"`, and rejects NUL bytes. SQL parameter binding doesn't apply to identifiers in any major engine, so this is the safe substitute.

- **Loader invariants encoded as types.** `classify_columns` filters non-fetchable columns at classification time so `fetch_dispatch` matches exhaustively over real targets. Each per-column task returns a `FetchResult` variant that bundles target metadata with its rows, so `apply_fetch_result` likewise matches exhaustively. No `panic!` / `unreachable!` in the loader path.

## Caller impact

`Tsdb::load` and `Tsdb::load_from_bytes` are `async fn` — callers must `.await` them and have a tokio runtime in their call path. Downstream consumers (Rezolus, etc.) pick this up on their own branches and aren't touched here.

## What this sets up

DuckDB is now the data path. Future PRs — lazy per-metric materialization, multi-file reads, column-range pushdown, eventually remote storage backends — slot into the same `spawn_blocking` + connection-pool pattern as additive changes rather than cross-cutting rewrites.

## Dependencies

`duckdb = "1.10503.1"` with the `bundled` feature, `tokio = "1"` with `rt` + `rt-multi-thread` + `macros`. Bundled DuckDB adds a one-time ~5–7 min C++ compile per profile; incremental builds within a profile stay fast (and `sccache` makes profile switches and Cargo.toml changes fast too).
