### PR TITLE
feat(query): add histogram_sum function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "arrow",
  "bytes",

--- a/metriken-query/Cargo.toml
+++ b/metriken-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken-query"
-version = "0.10.7"
+version = "0.10.8"
 edition = "2021"
 authors = [
     "Brian Martin <brian@iop.systems>",

--- a/metriken-query/src/promql/columns.rs
+++ b/metriken-query/src/promql/columns.rs
@@ -74,7 +74,12 @@ fn strip_rezolus_wrapper(query: &str) -> Result<&str, QueryError> {
         let (selector, _stride) = parse_optional_stride(inner.trim())?;
         return Ok(selector);
     }
-    for func in ["histogram_mean", "histogram_count", "histogram_irate"] {
+    for func in [
+        "histogram_mean",
+        "histogram_count",
+        "histogram_sum",
+        "histogram_irate",
+    ] {
         if let Some((inner, _group_by)) = parse_histogram_call(func, query)? {
             let (selector, _stride) = parse_optional_stride(inner.trim())?;
             return Ok(selector);

--- a/metriken-query/src/promql/mod.rs
+++ b/metriken-query/src/promql/mod.rs
@@ -187,9 +187,14 @@ fn unwrap_sum_around_histogram(query: &str) -> Option<String> {
     }
     let inner = after_open[..close].trim();
 
-    let inner_func = ["histogram_irate", "histogram_mean", "histogram_count"]
-        .iter()
-        .find(|f| inner.starts_with(*f))?;
+    let inner_func = [
+        "histogram_irate",
+        "histogram_mean",
+        "histogram_count",
+        "histogram_sum",
+    ]
+    .iter()
+    .find(|f| inner.starts_with(*f))?;
     let after_name = inner.strip_prefix(*inner_func)?;
     if !matches!(after_name.chars().next(), Some('(' | ' ' | '\t')) {
         return None;
@@ -656,6 +661,15 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
                 stride_ns,
                 &metric_name,
             ),
+            "histogram_sum" => streaming::histogram::sum(
+                collection,
+                &labels,
+                group,
+                start_ns,
+                end_ns,
+                stride_ns,
+                &metric_name,
+            ),
             _ => streaming::histogram::count(
                 collection,
                 &labels,
@@ -698,7 +712,7 @@ impl<T: Deref<Target = Tsdb>> QueryEngine<T> {
         let rewritten = unwrap_sum_around_histogram(query_str);
         let query_str: &str = rewritten.as_deref().unwrap_or(query_str);
 
-        for func in ["histogram_mean", "histogram_count"] {
+        for func in ["histogram_mean", "histogram_count", "histogram_sum"] {
             if let Some((inner, group_by)) = parse_histogram_call(func, query_str)? {
                 return self.handle_histogram_scalar(func, inner, group_by, start, end);
             }

--- a/metriken-query/src/promql/streaming/histogram.rs
+++ b/metriken-query/src/promql/streaming/histogram.rs
@@ -363,6 +363,37 @@ pub fn mean(
     )
 }
 
+/// Sum of all observations per `(group, tick)` — `count × mean` off
+/// the merged `Ref`, derived from bucket midpoints (the histogram crate
+/// doesn't store a separate Prometheus-native `sum` field). Both
+/// underlying reads are O(1) on the Ref.
+pub fn sum(
+    collection: &HistogramCollection,
+    label_filter: &Labels,
+    group_by: GroupBy<'_>,
+    start_ns: u64,
+    end_ns: u64,
+    stride_ns: Option<u64>,
+    metric_name: &str,
+) -> Vec<MatrixSample> {
+    reduce(
+        collection,
+        label_filter,
+        group_by,
+        start_ns,
+        end_ns,
+        stride_ns,
+        metric_name,
+        |r| {
+            let c = r.total_count();
+            if c == 0 {
+                return None;
+            }
+            r.mean().map(|m| c as f64 * m)
+        },
+    )
+}
+
 /// Total observation count per `(group, tick)` — `total_count()` off
 /// the merged `Ref`, no quantile walk.
 pub fn count(

--- a/metriken-query/src/promql/streaming/histogram.rs
+++ b/metriken-query/src/promql/streaming/histogram.rs
@@ -364,9 +364,9 @@ pub fn mean(
 }
 
 /// Sum of all observations per `(group, tick)` — `count × mean` off
-/// the merged `Ref`, derived from bucket midpoints (the histogram crate
-/// doesn't store a separate Prometheus-native `sum` field). Both
-/// underlying reads are O(1) on the Ref.
+/// the merged `Ref`. The histogram crate doesn't carry a native `sum`
+/// field, so this is bucket-midpoint-approximated (exact for values
+/// inside the linear region of the histogram config).
 pub fn sum(
     collection: &HistogramCollection,
     label_filter: &Labels,

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1405,9 +1405,7 @@ fn test_histogram_mean_is_bucket_weighted_midpoint() {
 
 #[test]
 fn test_histogram_sum_is_count_times_mean() {
-    // sum across all observations = count × bucket-midpoint. With
-    // value=10 landing in an exact bucket, mean is 10.0 and sum is
-    // 10.0 × count across both cpus.
+    // value=10 is an exact bucket so mean=10.0; sum = 10.0 × count.
     let tsdb = Arc::new(create_hist_exec_tsdb());
     let engine = QueryEngine::new(tsdb);
 
@@ -1424,7 +1422,6 @@ fn test_histogram_sum_is_count_times_mean() {
         Some("req_latency")
     );
     let sums: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
-    // counts are 10 then 14 (see histogram_count test), mean is 10.0.
     assert_eq!(sums, vec![100.0, 140.0]);
 }
 
@@ -1446,7 +1443,6 @@ fn test_histogram_sum_label_filter_selects_single_series() {
         panic!("expected Matrix, got {result:?}");
     };
     let sums: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
-    // counts per cpu are 5 then 7; mean is 10.0.
     assert_eq!(sums, vec![50.0, 70.0]);
 }
 
@@ -1466,7 +1462,6 @@ fn test_histogram_sum_by_emits_per_group_series() {
     assert_eq!(result.len(), 2);
     for series in &result {
         let sums: Vec<f64> = series.values.iter().map(|(_, v)| *v).collect();
-        // per cpu: counts 5,7 × mean 10.0
         assert_eq!(sums, vec![50.0, 70.0]);
     }
 }

--- a/metriken-query/src/promql/tests.rs
+++ b/metriken-query/src/promql/tests.rs
@@ -1294,6 +1294,20 @@ fn test_columns_histogram_count_with_label_filter() {
     );
 }
 
+#[test]
+fn test_columns_histogram_sum_resolves_buckets_column() {
+    let tsdb = Arc::new(create_columns_histogram_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let cols = engine.columns("histogram_sum(tcp_packet_latency)").unwrap();
+    assert_eq!(
+        cols,
+        ["tcp_packet_latency:buckets".to_string()]
+            .into_iter()
+            .collect()
+    );
+}
+
 // Cumulative-since-start histograms (the ingest delta path requires
 // monotonic snapshots). Two label series (`cpu` 0/1), each with
 // cumulative observation counts [0, 5, 12] all landing in the exact
@@ -1387,6 +1401,108 @@ fn test_histogram_mean_is_bucket_weighted_midpoint() {
         assert!((v - 10.0).abs() < 1e-9, "mean should be 10.0, got {v}");
     }
     assert!(!result[0].values.is_empty());
+}
+
+#[test]
+fn test_histogram_sum_is_count_times_mean() {
+    // sum across all observations = count × bucket-midpoint. With
+    // value=10 landing in an exact bucket, mean is 10.0 and sum is
+    // 10.0 × count across both cpus.
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("histogram_sum(req_latency)", 1000.0, 1003.0, 1.0)
+        .unwrap();
+
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0].metric.get("__name__").map(String::as_str),
+        Some("req_latency")
+    );
+    let sums: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    // counts are 10 then 14 (see histogram_count test), mean is 10.0.
+    assert_eq!(sums, vec![100.0, 140.0]);
+}
+
+#[test]
+fn test_histogram_sum_label_filter_selects_single_series() {
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range(
+            r#"histogram_sum(req_latency{cpu="0"})"#,
+            1000.0,
+            1003.0,
+            1.0,
+        )
+        .unwrap();
+
+    let QueryResult::Matrix { result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    let sums: Vec<f64> = result[0].values.iter().map(|(_, v)| *v).collect();
+    // counts per cpu are 5 then 7; mean is 10.0.
+    assert_eq!(sums, vec![50.0, 70.0]);
+}
+
+#[test]
+fn test_histogram_sum_by_emits_per_group_series() {
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine
+        .query_range("histogram_sum by (cpu) (req_latency)", 1000.0, 1003.0, 1.0)
+        .unwrap();
+
+    let QueryResult::Matrix { mut result } = result else {
+        panic!("expected Matrix, got {result:?}");
+    };
+    result.sort_by(|a, b| a.metric.get("cpu").cmp(&b.metric.get("cpu")));
+    assert_eq!(result.len(), 2);
+    for series in &result {
+        let sums: Vec<f64> = series.values.iter().map(|(_, v)| *v).collect();
+        // per cpu: counts 5,7 × mean 10.0
+        assert_eq!(sums, vec![50.0, 70.0]);
+    }
+}
+
+#[test]
+fn test_histogram_sum_metric_not_found() {
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let result = engine.query_range("histogram_sum(does_not_exist)", 1000.0, 1003.0, 1.0);
+    match result {
+        Err(QueryError::MetricNotFound(_)) => {}
+        other => panic!("expected MetricNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_sum_wrapping_histogram_sum_matches_bare() {
+    let tsdb = Arc::new(create_hist_exec_tsdb());
+    let engine = QueryEngine::new(tsdb);
+
+    let bare = engine
+        .query_range("histogram_sum(req_latency)", 1000.0, 1003.0, 1.0)
+        .unwrap();
+    let wrapped = engine
+        .query_range("sum(histogram_sum(req_latency))", 1000.0, 1003.0, 1.0)
+        .unwrap();
+
+    let values_of = |r: QueryResult| -> Vec<f64> {
+        let QueryResult::Matrix { result } = r else {
+            panic!("expected Matrix");
+        };
+        assert_eq!(result.len(), 1);
+        result[0].values.iter().map(|(_, v)| *v).collect()
+    };
+    assert_eq!(values_of(bare), values_of(wrapped));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the `histogram_sum(m)` PromQL function, mirroring the existing `histogram_mean` / `histogram_count` shape. Returns the per-timestamp sum of all observations (≈ `count × mean` derived from bucket midpoints, since the histogram crate doesn't store a separate Prometheus-native `sum` field).

For typical rezolus histograms (`grouping_power=4`, values < 16 fall in exact-width buckets) the value is exact; for wider values it's bucket-midpoint-approximated.

Both underlying reads (`total_count`, `mean`) are O(1) on the `Ref`, so the operator costs the same as `histogram_count` or `histogram_mean`.

## API

- `histogram_sum(m)`
- `histogram_sum(m{label=...})`
- `histogram_sum by (cpu) (m)`
- `histogram_sum without (cpu) (m)`
- `sum(histogram_sum(m))` and `sum by (...) (histogram_sum(m))` via the existing rewriter
- Resolves through `QueryEngine::columns()` for parquet prefetch

## Test plan

- [x] 6 new TDD tests covering bare, label-filtered, by-grouped, MetricNotFound, sum-wrapped, and parquet column resolution
- [x] `cargo test --workspace` — all 90 metriken-query tests pass
- [x] `cargo fmt`, `cargo clippy -p metriken-query --all-features` clean (one pre-existing unrelated warning)

Bumps `metriken-query` to **0.10.8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)